### PR TITLE
feat: predicate props becomes edge props

### DIFF
--- a/src/core/state/patchGraph.ts
+++ b/src/core/state/patchGraph.ts
@@ -299,36 +299,6 @@ function* graphAssertion<M extends GraphState>(
 				return;
 			}
 
-			type EdgeProps = {
-				key: string;
-				value: string;
-			};
-			let newEdgeProperties: EdgeProps[] = [];
-			// Predicate
-			if (!state.nodeIndex.has(pTerm)) {
-				pNode = (nodeCache?.get(pTerm) as GraphMetadata) || { id: pTerm, type: 'metadata', ...initM() };
-				state.nodeIndex.set(pTerm, pNode);
-			} else {
-				const p = state.nodeIndex.get(pTerm)!;
-				if (p.type === 'metadata') {
-					pNode = p;
-				} else {
-					yield* changeNodeType(state, p, 'metadata');
-					pNode = p as any as GraphMetadata;
-				}
-				// store properties from old node (maybe just converted metadata node) in newEdgeProperties so they can be yielded later
-				for (const prop of pNode.properties.keys()) {
-					if (edgePredicate2prop.hasOwnProperty(prop)) {
-						const values = pNode.properties.get(prop);
-						if (values) {
-							for (const value of values) {
-								newEdgeProperties.push({ key: edgePredicate2prop[prop], value });
-							}
-						}
-					}
-				}
-			}
-
 			// Object IRI
 			if (!state.nodeIndex.has(oTerm)) {
 				switch (pTerm) {
@@ -356,6 +326,36 @@ function* graphAssertion<M extends GraphState>(
 					case typeIri:
 						yield* changeNodeType(state, oNode, 'metadata');
 						break;
+				}
+			}
+
+			type EdgeProps = {
+				key: string;
+				value: string;
+			};
+			let newEdgeProperties: EdgeProps[] = [];
+			// Predicate
+			if (!state.nodeIndex.has(pTerm)) {
+				pNode = (nodeCache?.get(pTerm) as GraphMetadata) || { id: pTerm, type: 'metadata', ...initM() };
+				state.nodeIndex.set(pTerm, pNode);
+			} else {
+				const p = state.nodeIndex.get(pTerm)!;
+				if (p.type === 'metadata') {
+					pNode = p;
+				} else {
+					yield* changeNodeType(state, p, 'metadata');
+					pNode = p as any as GraphMetadata;
+				}
+				// store properties from old node (maybe just converted metadata node) in newEdgeProperties so they can be yielded later
+				for (const prop of pNode.properties.keys()) {
+					if (edgePredicate2prop.hasOwnProperty(prop)) {
+						const values = pNode.properties.get(prop);
+						if (values) {
+							for (const value of values) {
+								newEdgeProperties.push({ key: edgePredicate2prop[prop], value });
+							}
+						}
+					}
 				}
 			}
 

--- a/src/core/state/patchGraph.ts
+++ b/src/core/state/patchGraph.ts
@@ -33,8 +33,9 @@ import {
 	hasDirectionIri,
 	typeIri,
 } from '../mapper/predicates';
+
 import { getSymbol, Point } from '../../symbol-api';
-import { flatMap, unique } from '../utils/iteratorUtils';
+import { flat, flatMap, unique } from '../utils/iteratorUtils';
 
 const writer = new Writer();
 const quadToString = ({ subject, predicate, object, graph }: Quad) => writer.quadToString(subject, predicate, object, graph);
@@ -124,6 +125,12 @@ const predicate2prop: { [index: string]: NodeProp | ValueProp } = {
 	[hasNodeTemplateIri]: nodeTemplateKey,
 	[hasDirectionIri]: directionKey,
 };
+
+const edgePredicate2prop: { [index: string]: ValueProp } = {
+	[labelIri]: labelKey,
+	[colorIri]: colorKey,
+};
+
 function* propagator(a: AbstractNode, prop: NodeProp | ValueProp) {
 	for (const dep of propertyDependents[prop]) {
 		let queue = [...dep];
@@ -131,7 +138,6 @@ function* propagator(a: AbstractNode, prop: NodeProp | ValueProp) {
 		let currDep = queue.shift()!;
 		while (queue.length > 0) {
 			if (Array.isArray(currNode)) {
-				// TODO ask Eirik about this
 				// eslint-disable-next-line no-loop-func
 				currNode = currNode.map((n) => n[currDep]).filter((n) => n);
 			} else {
@@ -170,8 +176,7 @@ const propInvalidations: { [index in NodeProp | ValueProp]: (node: AbstractNode)
 	symbol: invalidator('symbol', (g) => (g['symbolName'] ? getSymbol(g['symbolName'], { rotation: g[rotationKey] }) : undefined)),
 	connectorName: invalidator('connectorName', hasConnectorSuffixIri),
 	relativePosition: invalidator('relativePosition', ({ type, node, connectorName }) => {
-		if (type !== 'connector' || !node) return undefined;
-		if (!connectorName || !node.symbol) return new Point(0, 0);
+		if (type !== 'connector' || !node || !connectorName || !node.symbol) return undefined;
 		const c = node.symbol.connectors.find(({ id }) => id === connectorName);
 		return c?.point || new Point(0, 0);
 	}),
@@ -197,7 +202,6 @@ const propInvalidations: { [index in NodeProp | ValueProp]: (node: AbstractNode)
 const dependentQuads = (n: AbstractNode) =>
 	unique(
 		(function* (n: AbstractNode) {
-			// const set = new Set<Quad>();
 			for (const [iri, vals] of n.properties.entries())
 				for (const l of vals) yield new Quad(termFromId(n.id, DataFactory), termFromId(iri, DataFactory), DataFactory.literal(l));
 			for (const val of n.outgoing.values())
@@ -219,6 +223,7 @@ function* changeNodeType(s: GraphState, n: AbstractNode, type: AbstractNode['typ
 
 	// fetch sub-graph directly connected to this node
 	const quads = [...dependentQuads(n)];
+
 	// seed node-cache with changed node
 	const nodeCache = new Map<string, AbstractNode>();
 	// disconnect the node completely (remove properties, incoming/outgoing edges and lastly the node itself)
@@ -226,7 +231,7 @@ function* changeNodeType(s: GraphState, n: AbstractNode, type: AbstractNode['typ
 
 	// the ol' switcharoo
 	n.type = type;
-	switch (n.type) {
+	switch (type) {
 		case 'node':
 			delete n.edges;
 			delete n.node;
@@ -235,7 +240,7 @@ function* changeNodeType(s: GraphState, n: AbstractNode, type: AbstractNode['typ
 			delete n.edges;
 			break;
 		case 'metadata':
-			n.edges = n.edges || [];
+			n.edges = n.edges || new Map();
 			delete n.node;
 			break;
 	}
@@ -252,7 +257,7 @@ function* graphAssertion<M extends GraphState>(
 	nodeCache?: Map<string, AbstractNode>
 ): Iterable<GraphAssertion> {
 	const q = assertion;
-	let sNode: AbstractNode, pNode: GraphMetadata, oNode: AbstractNode;
+	let sNode: AbstractNode, pNode: AbstractNode, oNode: AbstractNode;
 	const sTerm = termToId(q.subject);
 	const pTerm = termToId(q.predicate);
 	const isConnectorPredicate = pTerm === hasConnectorIri;
@@ -264,31 +269,69 @@ function* graphAssertion<M extends GraphState>(
 			if (!state.nodeIndex.has(sTerm)) {
 				sNode = nodeCache?.get(sTerm) || { type: 'node', id: sTerm, ...initAN() };
 				state.nodeIndex.set(sTerm, sNode);
-				yield { action: 'add', assertion: sNode };
+				if (sNode.type !== 'metadata') {
+					yield { action: 'add', assertion: sNode };
+				}
 			} else {
+				//Handle existing predicate...
 				sNode = state.nodeIndex.get(sTerm)!;
 			}
 			// Object literal
 			if (!oTerm) {
 				add(sNode.properties, pTerm, q.object.value);
-
-				if (predicate2prop.hasOwnProperty(pTerm)) {
+				if (sNode.type === 'metadata') {
+					if (edgePredicate2prop.hasOwnProperty(pTerm)) {
+						const edges = flat(sNode.edges.values());
+						for (const edge of edges) {
+							yield {
+								action: 'add',
+								assertion: { type: 'property', key: edgePredicate2prop[pTerm], value: q.object.value, node: edge },
+							};
+						}
+					} else {
+						console.warn(
+							`${sTerm} is used as predicate before and subject now, but ${pTerm} is an unknown predicate, triple will be ignored.`
+						);
+					}
+				} else if (predicate2prop.hasOwnProperty(pTerm)) {
 					yield* propInvalidations[predicate2prop[pTerm] as ValueProp](sNode);
 				}
 				return;
 			}
+			type FindByType<Type, Discriminator> = Type extends { type: Discriminator } ? Type : never;
+			type NodeOf<Discriminator extends AbstractNode['type']> = FindByType<AbstractNode, Discriminator>;
+			const convertNode = <T extends AbstractNode['type']>(node: AbstractNode, type: T): NodeOf<T> => {
+				node.type = type;
+				return node as NodeOf<T>;
+			};
+
+			type EdgeProps = {
+				key: string;
+				value: string;
+			};
+			let newEdgeProperties: EdgeProps[] = [];
 			// Predicate
 			if (!state.nodeIndex.has(pTerm)) {
 				pNode = (nodeCache?.get(pTerm) as GraphMetadata) || { id: pTerm, type: 'metadata', ...initM() };
 				state.nodeIndex.set(pTerm, pNode);
-				yield { action: 'add', assertion: pNode };
 			} else {
 				const p = state.nodeIndex.get(pTerm)!;
 				if (p.type === 'metadata') {
 					pNode = p;
 				} else {
-					pNode = p as any as GraphMetadata;
 					yield* changeNodeType(state, p, 'metadata');
+					pNode = convertNode(p, 'metadata');
+				}
+				// store properties from old node (maybe just converted metadata node) in newEdgeProperties so they can be yielded later
+				for (const prop of pNode.properties.keys()) {
+					if (edgePredicate2prop.hasOwnProperty(prop)) {
+						const values = pNode.properties.get(prop);
+						if (values) {
+							for (const value of values) {
+								newEdgeProperties.push({ key: edgePredicate2prop[prop], value });
+							}
+						}
+					}
 				}
 			}
 
@@ -297,16 +340,17 @@ function* graphAssertion<M extends GraphState>(
 				switch (pTerm) {
 					case hasConnectorIri:
 						oNode = nodeCache?.get(oTerm) || ({ id: oTerm, type: 'connector', node: sNode, ...initAN() } as GraphConnector);
+						yield { action: 'add', assertion: oNode };
 						break;
 					case typeIri:
 						oNode = nodeCache?.get(oTerm) || ({ id: oTerm, type: 'metadata', ...initM() } as GraphMetadata);
 						break;
 					default:
 						oNode = nodeCache?.get(oTerm) || ({ id: oTerm, type: 'node', ...initAN() } as GraphNode);
+						yield { action: 'add', assertion: oNode };
 						break;
 				}
 				state.nodeIndex.set(oTerm, oNode);
-				yield { action: 'add', assertion: oNode };
 			} else {
 				oNode = state.nodeIndex.get(oTerm)!;
 
@@ -320,6 +364,7 @@ function* graphAssertion<M extends GraphState>(
 						break;
 				}
 			}
+
 			let edge: GraphEdge = {
 				id: quadToString(q),
 				metadata: pNode,
@@ -342,6 +387,10 @@ function* graphAssertion<M extends GraphState>(
 				sNode[connectorKey]!.push(oNode as GraphConnector);
 			} else if (pTerm === typeIri) {
 				// not part of visual edges, for now do nothing more than keep in property-graph
+			} else if (sNode.type === 'metadata') {
+				console.warn(
+					`${sTerm} is used as predicate before and subject now, but ${oTerm} is an IRI, only literals allowed when using predicates as subject, triple will be ignored.`
+				);
 			} else if (sNode.type === 'connector' || oNode.type === 'connector') {
 				// source and|or target node is a connector, track and yield an edge hooked up to connectors
 				let sc: Partial<GraphEdge>, tc: Partial<GraphEdge>;
@@ -368,14 +417,20 @@ function* graphAssertion<M extends GraphState>(
 				add(pNode.edges, connectorEdge.id, connectorEdge);
 				state.linkIndex.set(connectorEdge.id, connectorEdge);
 
-				const edgeAssertion: EdgeAssertion = { action: 'add', assertion: connectorEdge };
-				yield edgeAssertion;
+				const connectorEdgeAssertion: EdgeAssertion = { action: 'add', assertion: connectorEdge };
+				yield connectorEdgeAssertion;
+				for (const prop of newEdgeProperties) {
+					yield { action: 'add', assertion: { type: 'property', key: prop.key, value: prop.value, node: connectorEdge } };
+				}
 			} else {
 				// regular edge, no connectors. Track and yield.
 				state.linkIndex.set(edge.id, edge);
 
 				const edgeAssertion: EdgeAssertion = { action: 'add', assertion: edge };
 				yield edgeAssertion;
+				for (const prop of newEdgeProperties) {
+					yield { action: 'add', assertion: { type: 'property', key: prop.key, value: prop.value, node: edge } };
+				}
 			}
 			if (predicate2prop.hasOwnProperty(pTerm)) {
 				// calculate dependencies (if any)
@@ -391,6 +446,16 @@ function* graphAssertion<M extends GraphState>(
 				if (predicate2prop.hasOwnProperty(pTerm)) {
 					yield* propInvalidations[predicate2prop[pTerm] as ValueProp](sNode);
 				}
+
+				if (edgePredicate2prop.hasOwnProperty(pTerm) && sNode.type === 'metadata') {
+					const edges = flat(sNode.edges.values());
+					for (const edge of edges) {
+						yield {
+							action: 'remove',
+							assertion: { type: 'property', key: edgePredicate2prop[pTerm], value: q.object.value, node: edge },
+						};
+					}
+				}
 			} else {
 				oNode = state.nodeIndex.get(oTerm)!;
 				const edgeId = quadToString(q);
@@ -401,14 +466,9 @@ function* graphAssertion<M extends GraphState>(
 				if (isConnectorPredicate) {
 					// sNode.
 					removeElement(sNode[connectorKey]!, oNode);
-					// yield { action: 'remove', assertion: { type: 'property', node: sNode, key: connectorKey, value: oNode } };
 					if (oNode.type === 'connector' && (oNode.incoming.get(hasConnectorIri) || []).length < 1) {
 						yield* changeNodeType(state, oNode, 'node');
 					}
-					// if ((oNode.incoming.get(hasConnectorIri) || []).length > 0) {
-					// 	oNode.node = oNode.incoming.get(hasConnectorIri)![0];
-					// 	yield* changeNodeType(state, oNode, 'connector');
-					// }
 				} else if (pTerm === typeIri) {
 				} else {
 					const edge = state.linkIndex.get(edgeId)!;
@@ -426,6 +486,16 @@ function* graphAssertion<M extends GraphState>(
 						remove(target.incoming, pTerm, edge);
 					}
 
+					for (const prop of pNode.properties.keys()) {
+						if (edgePredicate2prop.hasOwnProperty(prop)) {
+							const values = pNode.properties.get(prop);
+							if (values) {
+								for (const value of values) {
+									yield { action: 'remove', assertion: { type: 'property', key: prop, value: value, node: edge } };
+								}
+							}
+						}
+					}
 					const edgeAssertion: EdgeAssertion = { action: 'remove', assertion: edge };
 					yield edgeAssertion;
 				}
@@ -443,7 +513,6 @@ function* graphAssertion<M extends GraphState>(
 				if (refCount(pNode) < 1) {
 					state.nodeIndex.delete(pTerm);
 					nodeCache?.set(pNode.id, pNode);
-					yield { action: 'remove', assertion: pNode };
 				} else if (pNode.edges.size < 1) {
 					yield* changeNodeType(state, pNode, 'node');
 				}
@@ -452,8 +521,9 @@ function* graphAssertion<M extends GraphState>(
 			if (refCount(sNode) < 1) {
 				state.nodeIndex.delete(sTerm);
 				nodeCache?.set(sNode.id, sNode);
-
-				yield { action: 'remove', assertion: sNode };
+				if (sNode.type !== 'metadata') {
+					yield { action: 'remove', assertion: sNode };
+				}
 			}
 
 			break;

--- a/src/core/state/patchGraph.ts
+++ b/src/core/state/patchGraph.ts
@@ -298,12 +298,6 @@ function* graphAssertion<M extends GraphState>(
 				}
 				return;
 			}
-			type FindByType<Type, Discriminator> = Type extends { type: Discriminator } ? Type : never;
-			type NodeOf<Discriminator extends AbstractNode['type']> = FindByType<AbstractNode, Discriminator>;
-			const convertNode = <T extends AbstractNode['type']>(node: AbstractNode, type: T): NodeOf<T> => {
-				node.type = type;
-				return node as NodeOf<T>;
-			};
 
 			type EdgeProps = {
 				key: string;
@@ -320,7 +314,7 @@ function* graphAssertion<M extends GraphState>(
 					pNode = p;
 				} else {
 					yield* changeNodeType(state, p, 'metadata');
-					pNode = convertNode(p, 'metadata');
+					pNode = p as any as GraphMetadata;
 				}
 				// store properties from old node (maybe just converted metadata node) in newEdgeProperties so they can be yielded later
 				for (const prop of pNode.properties.keys()) {

--- a/src/core/tests/patchGraph/graphState.test.tsx
+++ b/src/core/tests/patchGraph/graphState.test.tsx
@@ -3,12 +3,12 @@ import { patchGraph } from '../../state/patchGraph';
 import { termToId } from 'n3';
 import * as P from '../../mapper/predicates';
 import { SymbolKey } from '../../../symbol-api';
-import { emptyGraph, svgWithConnectorQuads, toPatch } from './testUtils';
+import { emptyGraph, svgWithConnectorQuads, toAddPatch } from './testUtils';
 
 describe('patchGraph', () => {
 	test('normal svg', () => {
 		const quads = svgWithConnectorQuads('c1');
-		const res = patchGraph(emptyGraph(), toPatch(quads));
+		const res = patchGraph(emptyGraph(), toAddPatch(quads));
 		for (const _ of res.graphPatch) {
 		}
 		for (const q of quads) {
@@ -39,7 +39,7 @@ describe('patchGraph', () => {
 	});
 
 	test('Without existing connector', () => {
-		const res = patchGraph(emptyGraph(), toPatch(svgWithConnectorQuads("I don't exist in Seperator_1")));
+		const res = patchGraph(emptyGraph(), toAddPatch(svgWithConnectorQuads("I don't exist in Seperator_1")));
 		for (const _ of res.graphPatch) {
 		}
 		expect(res.graphState.nodeIndex.get('C')!.relativePosition!).toMatchObject({ x: 0, y: 0 });

--- a/src/core/tests/patchGraph/patchOrder.test.tsx
+++ b/src/core/tests/patchGraph/patchOrder.test.tsx
@@ -4,7 +4,7 @@ import { createState, SimplifiedAssertion, testPatchOrder, toAddPatch, toRmPatch
 
 const { quad: q, literal: l, namedNode: n } = DataFactory;
 
-test.skip('Node becomes connector and node again', () => {
+test('Node becomes connector and node again', () => {
 	const originalData = [
 		q(n('N1'), P.labelPredicate, l('Node 1')),
 		q(n('N1'), P.hasSvgPredicate, l('Separator_1')),
@@ -46,7 +46,7 @@ test.skip('Node becomes connector and node again', () => {
 	testPatchOrder(addedState.graphState, rmChange, expectedRmOrder);
 });
 
-test.skip('Edges becomes colored', () => {
+test('Edges becomes colored', () => {
 	const originalData = [
 		q(n('N1'), P.labelPredicate, l('Node 1')),
 		q(n('N2'), P.labelPredicate, l('Node 2')),

--- a/src/core/tests/patchGraph/patchOrder.test.tsx
+++ b/src/core/tests/patchGraph/patchOrder.test.tsx
@@ -1,86 +1,124 @@
-import { DataFactory, Quad } from 'n3';
+import { DataFactory } from 'n3';
 import * as P from '../../mapper/predicates';
-import { patchGraph } from '../../state/patchGraph';
-import { emptyGraph, toPatch } from './testUtils';
+import { createState, SimplifiedAssertion, testPatchOrder, toAddPatch, toRmPatch } from './testUtils';
 
 const { quad: q, literal: l, namedNode: n } = DataFactory;
 
-type SimplifiedAssertion = { type: 'metadata' | 'property' | 'node' | 'edge' | 'connector' | 'NA'; action: 'add' | 'remove' | 'NA' };
-
-type DebugElement = {
-	expected: SimplifiedAssertion;
-	actual: SimplifiedAssertion;
-};
-
-test('Node becomes connector', () => {
+test.skip('Node becomes connector and node again', () => {
 	const originalData = [
 		q(n('N1'), P.labelPredicate, l('Node 1')),
 		q(n('N1'), P.hasSvgPredicate, l('Separator_1')),
 		q(n('N2'), P.labelPredicate, l('Node 2')),
-		q(n('C'), P.hasConnectorSuffixPredicate, l('c1')),
+		q(n('N2'), P.hasConnectorSuffixPredicate, l('c1')),
 		q(n('N3'), P.labelPredicate, l('Node 3')),
 		q(n('N2'), n('isConnectedTo'), n('N3')),
 	];
 
-	const change = [q(n('N1'), P.hasConnectorPredicate, n('N2'))];
+	const quads = [q(n('N1'), P.hasConnectorPredicate, n('N2'))];
+	const addChange = toAddPatch(quads);
+	const rmChange = toRmPatch(quads);
 
 	const expectedOrder: SimplifiedAssertion[] = [
-		{ type: 'metadata', action: 'add' },
-		{ type: 'property', action: 'remove' },
-		{ type: 'edge', action: 'remove' },
-		{ type: 'metadata', action: 'remove' },
-		{ type: 'node', action: 'remove' },
-		{ type: 'connector', action: 'add' },
+		{ type: 'property', action: 'remove' }, // Label
+		{ type: 'property', action: 'remove' }, // Connector id
+		{ type: 'edge', action: 'remove' }, // Edge to N3
+		{ type: 'node', action: 'remove' }, // N2
+		{ type: 'connector', action: 'add' }, // N2 as connector
+		{ type: 'property', action: 'add' }, // Label
+		{ type: 'property', action: 'add' }, // Connector id
+		{ type: 'property', action: 'add' }, // Relative pos
+		{ type: 'edge', action: 'add' }, // Edge to N3
+	];
+
+	const expectedRmOrder: SimplifiedAssertion[] = [
+		{ type: 'property', action: 'remove' }, // Lable
+		{ type: 'property', action: 'remove' }, // Connector id
+		{ type: 'property', action: 'remove' }, // Relative pos from svg api
+		{ type: 'edge', action: 'remove' }, // Edge to N3
+		{ type: 'connector', action: 'remove' }, // N2 as Connector
+		{ type: 'node', action: 'add' }, // N2 as Node
+		{ type: 'property', action: 'add' }, // Label
+		{ type: 'property', action: 'add' }, // Connector id
+		{ type: 'edge', action: 'add' }, // Edge to N3
+	];
+
+	const addedState = testPatchOrder(createState(originalData), addChange, expectedOrder);
+	testPatchOrder(addedState.graphState, rmChange, expectedRmOrder);
+});
+
+test.skip('Edges becomes colored', () => {
+	const originalData = [
+		q(n('N1'), P.labelPredicate, l('Node 1')),
+		q(n('N2'), P.labelPredicate, l('Node 2')),
+		q(n('N3'), P.labelPredicate, l('Node 3')),
+		q(n('N1'), n('isConnectedTo'), n('N2')),
+		q(n('N2'), n('isConnectedTo'), n('N3')),
+	];
+
+	const change = toAddPatch([q(n('isConnectedTo'), P.colorPredicate, l('green'))]);
+
+	const expectedOrder: SimplifiedAssertion[] = [
 		{ type: 'property', action: 'add' },
-		{ type: 'metadata', action: 'add' },
+		{ type: 'property', action: 'add' },
+	];
+
+	testPatchOrder(createState(originalData), change, expectedOrder);
+});
+
+test('Edge from predicate with color', () => {
+	const originalData = [
+		q(n('N1'), P.labelPredicate, l('Node 1')),
+		q(n('N2'), P.labelPredicate, l('Node 2')),
+		q(n('N3'), P.labelPredicate, l('Node 3')),
+
+		q(n('isConnectedTo'), P.colorPredicate, l('green')),
+	];
+
+	const change = toAddPatch([q(n('N1'), n('isConnectedTo'), n('N2')), q(n('N2'), n('isConnectedTo'), n('N3'))]);
+
+	const expectedOrder: SimplifiedAssertion[] = [
+		{ type: 'property', action: 'remove' },
+		{ type: 'node', action: 'remove' },
+		{ type: 'edge', action: 'add' },
+		{ type: 'property', action: 'add' },
 		{ type: 'edge', action: 'add' },
 		{ type: 'property', action: 'add' },
 	];
 
-	testPatchOrder(originalData, change, expectedOrder);
+	testPatchOrder(createState(originalData), change, expectedOrder);
 });
 
-const testPatchOrder = (originalData: Quad[], change: Quad[], expectedOrder: SimplifiedAssertion[]) => {
-	const originalRes = patchGraph(emptyGraph(), toPatch(originalData));
-	for (const _patch of originalRes.graphPatch) {
-	}
+test('Edge remove color', () => {
+	const originalData = [
+		q(n('N1'), P.labelPredicate, l('Node 1')),
+		q(n('N2'), P.labelPredicate, l('Node 2')),
+		q(n('N1'), n('isConnectedTo'), n('N2')),
+		q(n('isConnectedTo'), P.colorPredicate, l('green')),
+	];
 
-	const changeRes = patchGraph(originalRes.graphState, toPatch(change));
-	let actualAssertions: SimplifiedAssertion[] = [];
+	const change = toRmPatch([q(n('isConnectedTo'), P.colorPredicate, l('green'))]);
 
-	for (const assertion of changeRes.graphPatch) {
-		actualAssertions.push({ type: assertion.assertion.type, action: assertion.action });
-	}
+	const expectedOrder: SimplifiedAssertion[] = [{ type: 'property', action: 'remove' }];
 
-	if (actualAssertions.length !== expectedOrder.length) {
-		printDebugArray(expectedOrder, actualAssertions);
-		throw new Error('Length of actual and expected assertions differs');
-	}
+	testPatchOrder(createState(originalData), change, expectedOrder);
+});
 
-	for (let i = 0; i < expectedOrder.length; i++) {
-		if (expectedOrder[i].action !== actualAssertions[i].action || expectedOrder[i].type !== actualAssertions[i].type) {
-			printDebugArray(expectedOrder, actualAssertions);
-			console.log(expectedOrder[i], actualAssertions[i]);
-			throw new Error('Actual and expected assertions differs at element ' + i);
-		}
-	}
-};
+test('Remove edge with color', () => {
+	const originalData = [
+		q(n('N1'), P.labelPredicate, l('Node 1')),
+		q(n('N2'), P.labelPredicate, l('Node 2')),
+		q(n('N1'), n('isConnectedTo'), n('N2')),
+		q(n('isConnectedTo'), P.colorPredicate, l('green')),
+	];
 
-const printDebugArray = (expected: SimplifiedAssertion[], actual: SimplifiedAssertion[]) => {
-	const filledExpected = addFillElements(expected, actual.length - expected.length);
-	const filledActual = addFillElements(actual, expected.length - actual.length);
+	const change = toRmPatch([q(n('N1'), n('isConnectedTo'), n('N2'))]);
 
-	const debugArray: DebugElement[] = [];
-	for (let i = 0; i < filledExpected.length; i++) {
-		debugArray.push({ expected: filledExpected[i], actual: filledActual[i] });
-	}
-	console.table(debugArray);
-};
+	const expectedOrder: SimplifiedAssertion[] = [
+		{ type: 'property', action: 'remove' },
+		{ type: 'edge', action: 'remove' },
+		{ type: 'node', action: 'add' },
+		{ type: 'property', action: 'add' },
+	];
 
-const addFillElements = (array: SimplifiedAssertion[], n: number) => {
-	const newArray = [...array];
-	for (let i = 0; i < n; i++) {
-		newArray.push({ type: 'NA', action: 'NA' });
-	}
-	return newArray;
-};
+	testPatchOrder(createState(originalData), change, expectedOrder);
+});

--- a/src/core/tests/patchGraph/testUtils.ts
+++ b/src/core/tests/patchGraph/testUtils.ts
@@ -1,9 +1,17 @@
 import { DataFactory, Quad } from 'n3';
-import { GraphEdge, GraphNode } from '../../types';
+import { GraphEdge, GraphNode, GraphState } from '../../types';
 import { RdfPatch2 } from '../../types/rdfPatch';
 
 import * as P from '../../mapper/predicates';
+import { patchGraph } from '../../state/patchGraph';
 const { quad: q, literal: l, namedNode: n } = DataFactory;
+
+export type SimplifiedAssertion = { type: 'metadata' | 'property' | 'node' | 'edge' | 'connector' | 'NA'; action: 'add' | 'remove' | 'NA' };
+
+export type DebugElement = {
+	expected: SimplifiedAssertion;
+	actual: SimplifiedAssertion;
+};
 
 export const svgWithConnectorQuads = (connectorId: string) => [
 	q(n('S'), P.hasSvgPredicate, l('Separator_1')),
@@ -11,10 +19,64 @@ export const svgWithConnectorQuads = (connectorId: string) => [
 	q(n('C'), P.hasConnectorSuffixPredicate, l(connectorId)),
 ];
 
-export const emptyGraph = () => {
+export const emptyGraph = (): GraphState => {
 	return { linkIndex: new Map<string, GraphEdge>(), nodeIndex: new Map<string, GraphNode>() };
 };
-export const toPatch = (quads: Quad[]): RdfPatch2 =>
+
+export const createState = (quads: Quad[]): GraphState => {
+	const originalRes = patchGraph(emptyGraph(), toAddPatch(quads));
+	for (const _patch of originalRes.graphPatch) {
+	}
+	return originalRes.graphState;
+};
+
+export const toAddPatch = (quads: Quad[]): RdfPatch2 =>
 	quads.map((quad) => {
 		return { action: 'add', assertion: quad };
 	});
+
+export const toRmPatch = (quads: Quad[]): RdfPatch2 =>
+	quads.map((quad) => {
+		return { action: 'remove', assertion: quad };
+	});
+
+export const testPatchOrder = (originalData: GraphState, change: RdfPatch2, expectedOrder: SimplifiedAssertion[]) => {
+	const changeRes = patchGraph(originalData, change);
+	let actualAssertions: SimplifiedAssertion[] = [];
+
+	for (const assertion of changeRes.graphPatch) {
+		actualAssertions.push({ type: assertion.assertion.type, action: assertion.action });
+	}
+
+	if (actualAssertions.length !== expectedOrder.length) {
+		printDebugArray(expectedOrder, actualAssertions);
+		throw new Error('Length of actual and expected assertions differs');
+	}
+
+	for (let i = 0; i < expectedOrder.length; i++) {
+		if (expectedOrder[i].action !== actualAssertions[i].action || expectedOrder[i].type !== actualAssertions[i].type) {
+			printDebugArray(expectedOrder, actualAssertions);
+			throw new Error('Actual and expected assertions differs at element ' + i);
+		}
+	}
+	return changeRes;
+};
+
+export const printDebugArray = (expected: SimplifiedAssertion[], actual: SimplifiedAssertion[]) => {
+	const filledExpected = addFillElements(expected, actual.length - expected.length);
+	const filledActual = addFillElements(actual, expected.length - actual.length);
+
+	const debugArray: DebugElement[] = [];
+	for (let i = 0; i < filledExpected.length; i++) {
+		debugArray.push({ expected: filledExpected[i], actual: filledActual[i] });
+	}
+	console.table(debugArray);
+};
+
+export const addFillElements = (array: SimplifiedAssertion[], n: number) => {
+	const newArray = [...array];
+	for (let i = 0; i < n; i++) {
+		newArray.push({ type: 'NA', action: 'NA' });
+	}
+	return newArray;
+};

--- a/src/core/types/graphModel.ts
+++ b/src/core/types/graphModel.ts
@@ -53,7 +53,7 @@ export type GraphEdge = {
 	targetConnectorRef?: GraphConnector;
 	metadata: GraphMetadata;
 	origin: Quad | GraphEdge;
-};
+} & GraphVisualProps;
 
 export type GraphProperty = {
 	type: 'property';

--- a/src/core/utils/twoWayDictionary.ts
+++ b/src/core/utils/twoWayDictionary.ts
@@ -9,6 +9,14 @@ export class TwoWayMap {
 		}
 	}
 
+	keys() {
+		return Object.keys(this.dict);
+	}
+
+	values() {
+		return Object.keys(this.reverseMap);
+	}
+
 	includes(key: string) {
 		return this.dict.hasOwnProperty(key);
 	}

--- a/src/cyGraph/CyGraph.tsx
+++ b/src/cyGraph/CyGraph.tsx
@@ -25,22 +25,28 @@ const addNode = ({ id, type, node }: AbstractNode, cy: Cytoscape.Core) => {
 };
 
 const addProperty = ({ key, node, value }: GraphProperty, cy: Cytoscape.Core) => {
-	const nodeById = cy.getElementById(node.id);
+	const elementById = cy.getElementById(node.id);
 
 	switch (key) {
 		case 'symbol':
-			nodeById.data(nodeTypeKey, NodeType.SymbolContainer);
-			nodeById.data(key, value);
+			elementById.data(nodeTypeKey, NodeType.SymbolContainer);
+			elementById.data(key, value);
 			break;
 		case 'relativePosition':
-			nodeById.data(nodeTypeKey, NodeType.SymbolConnector);
-			nodeById.data(key, value);
+			elementById.data(nodeTypeKey, NodeType.SymbolConnector);
+			elementById.data(key, value);
 			break;
 		case 'parent':
-			nodeById.move({ parent: (node as any).parent!.id });
+			elementById.move({ parent: (node as any).parent!.id });
+			break;
+		case 'color':
+			if (elementById.isEdge()) {
+				elementById.data('lineColor', value);
+			}
+			elementById.data(key, value);
 			break;
 		default:
-			nodeById.data(key, value);
+			elementById.data(key, value);
 	}
 };
 
@@ -102,7 +108,6 @@ const applyPatch = (graphPatch: GraphPatch, cy: Cytoscape.Core) => {
 						if (assertion.key === 'symbol') {
 							createImageNode(assertion.node.id, (assertion.node as any).symbol!, cy);
 						}
-
 						break;
 					case 'edge':
 						if (assertion.metadata.id !== hasConnectorIri) {
@@ -283,12 +288,16 @@ export const CyGraph = ({ graphState, graphPatch, selectionEffect: onElementsSel
 						// 'curve-style': state.uiConfig.edgeStyle,
 						'curve-style': 'bezier',
 						width: '1px',
-						color: 'black',
-						'line-color': 'black',
 						'target-arrow-color': '#ccc',
 						'target-arrow-fill': 'filled',
 						'target-arrow-shape': 'chevron',
 						'arrow-scale': 1.5,
+					},
+				},
+				{
+					selector: `edge[${colorKey}]`,
+					style: {
+						'line-color': `data(${colorKey})`,
 					},
 				},
 			]}

--- a/src/cyGraph/storybook/StoryWrapper.tsx
+++ b/src/cyGraph/storybook/StoryWrapper.tsx
@@ -1,25 +1,40 @@
-import { Button } from '@equinor/eds-core-react';
+import { Button, Input, Table } from '@equinor/eds-core-react';
 import { useEffect, useState } from 'react';
 import { useRdfActionReducer } from '../../core/state/useRdfState';
 import { turtle2RdfTriples } from '../../core/mapper';
 import { createPatch } from '../createPatch';
 import { GraphSelection } from '../../core/types/graphModel';
 import { RdfCyGraph } from '../RdfCyGraph';
+import { DataFactory } from 'n3';
+
+const { namedNode } = DataFactory;
 
 export type SparqlWrapperProps = {
 	turtleString: string;
 };
 
+type Property = {
+	key: string;
+	value: string;
+};
+
 export const StoryWrapper = ({ turtleString }: SparqlWrapperProps) => {
 	const [turtle, updateTurtle] = useState<string>(turtleString);
-	const [nodeNumber, setNodeNumber] = useState<number>(1);
 
 	const [selection, setSelection] = useState<GraphSelection>([]);
 	const [state, dispatch] = useRdfActionReducer();
 
+	const [nodeIri, setNodeIri] = useState<string>('');
+	const [connectionPredicate, setConnectionPredicate] = useState<string>('');
+
+	const [valuePredicate, setValuePredicate] = useState<string>('http://rdf.equinor.com/ui/');
+	const [literalValue, setLiteralValue] = useState<string>('');
+	const [properties, setProperties] = useState<Property[]>([]);
+
 	const deleteSelection = () => {
 		const patch = [...createPatch({ type: 'deleteSelection', selection })];
 		dispatch({ type: 'patch', data: patch });
+		setSelection([]);
 	};
 
 	const rotateSelection = () => {
@@ -27,18 +42,43 @@ export const StoryWrapper = ({ turtleString }: SparqlWrapperProps) => {
 		dispatch({ type: 'patch', data: patch });
 	};
 
-	const addNode = () => {
-		const patch = createPatch({ type: 'addNode', iri: 'http://example.com/node' + nodeNumber, label: 'node' + nodeNumber });
+	const connectSelection = () => {
+		const patch = [...createPatch({ type: 'connectSelection', predicate: connectionPredicate, selection })];
 		dispatch({ type: 'patch', data: patch });
-		setNodeNumber((n) => n + 1);
+	};
+
+	const addNode = () => {
+		if (nodeIri) {
+			const patch = createPatch({ type: 'addNode', iri: nodeIri, label: nodeIri });
+			dispatch({ type: 'patch', data: patch });
+		}
 	};
 
 	const loadTurtle = (): void => {
 		updateTurtle(turtleString);
 	};
 
-	const handleSelection = (selection: GraphSelection) => {
-		setSelection(selection);
+	const addProperty = (): void => {
+		const patch = [...createPatch({ type: 'addProperty', key: valuePredicate, value: literalValue, selection: selection })];
+		dispatch({ type: 'patch', data: patch });
+	};
+
+	const handleSelection = (newSelection: GraphSelection) => {
+		const nodes = newSelection.filter((s) => s.type === 'node');
+		setSelection(newSelection);
+
+		if (newSelection.length !== 1 || !nodes[0]) {
+			setProperties([]);
+			return [];
+		}
+		const quads = state.rdfStore.match(namedNode(nodes[0].id), null, null);
+		let props: Property[] = [];
+		for (const q of quads) {
+			if (q.object.termType === 'Literal') {
+				props.push({ key: q.predicate.value, value: q.object.value });
+			}
+		}
+		setProperties(props);
 		return [];
 	};
 
@@ -47,13 +87,64 @@ export const StoryWrapper = ({ turtleString }: SparqlWrapperProps) => {
 		dispatch({ type: 'replace', data: quads });
 	}, [turtle]);
 
+	const handleConnectionPredicateSelect = (e: React.SyntheticEvent<HTMLInputElement, Event>) => {
+		setConnectionPredicate(e.currentTarget.value);
+	};
+
+	const handleNodeIdSelect = (e: React.SyntheticEvent<HTMLInputElement, Event>) => {
+		setNodeIri(e.currentTarget.value);
+	};
+
+	const handleValuePredicateSelect = (e: React.SyntheticEvent<HTMLInputElement, Event>) => {
+		setValuePredicate(e.currentTarget.value);
+	};
+
+	const handleValueSelect = (e: React.SyntheticEvent<HTMLInputElement, Event>) => {
+		setLiteralValue(e.currentTarget.value);
+	};
+
 	return (
 		<div>
 			<Button onClick={addNode}> Add </Button>
+			<Input onChange={(x) => handleNodeIdSelect(x)} />
 			<Button onClick={deleteSelection}> Delete </Button>
 			<Button onClick={rotateSelection}> Rotate </Button>
+			<Button onClick={connectSelection}> Connect </Button>
+			<Input onChange={(x) => handleConnectionPredicateSelect(x)} />
 			<Button onClick={loadTurtle}> Load turtle </Button>
 			<RdfCyGraph selectionEffect={handleSelection} {...state} />
+			<Table>
+				<Table.Head>
+					<Table.Row key="Details">
+						<Table.Cell key="subject">subject</Table.Cell>
+						<Table.Cell key="predicate">predicate</Table.Cell>
+						<Table.Cell key="object">object</Table.Cell>
+					</Table.Row>
+				</Table.Head>
+				<Table.Body>
+					{properties.map(({ key, value }, row_index) => (
+						<Table.Row key={`result_row${row_index}`}>
+							{' '}
+							<Table.Cell key={`result_cell${row_index}_subject`}> {selection[0]?.id} </Table.Cell>
+							<Table.Cell key={`result_cell${row_index}_predicate`}> {key} </Table.Cell>
+							<Table.Cell key={`result_cell${row_index}_object`}> {value} </Table.Cell>
+						</Table.Row>
+					))}
+					<Table.Row key={`add`}>
+						{' '}
+						<Table.Cell key={`result_cell_add_button`}>
+							{' '}
+							<Button onClick={addProperty} />
+						</Table.Cell>
+						<Table.Cell key={`result_cell_add_predicate`}>
+							<Input onChange={(x) => handleValuePredicateSelect(x)} value={valuePredicate} />
+						</Table.Cell>
+						<Table.Cell key={`result_cell_add_object`}>
+							<Input onChange={(x) => handleValueSelect(x)} />
+						</Table.Cell>
+					</Table.Row>
+				</Table.Body>
+			</Table>
 		</div>
 	);
 };

--- a/src/goGraph/applyPatch.ts
+++ b/src/goGraph/applyPatch.ts
@@ -128,15 +128,7 @@ function patchProperty(model: go.GraphLinksModel, { action, assertion }: Asserti
 			data = (parent.ports as PortData[])[idx] as PortData;
 			break;
 		case 'metadata':
-			const edges = flat(assertion.node.edges.values());
-			for (const edge of edges) {
-				console.log('Coloring ', edge.id);
-				patchProperty(model, {
-					action,
-					assertion: { ...assertion, node: edge },
-				});
-			}
-			return;
+			break;
 		default:
 			data = model.findNodeDataForKey(assertion.node.id) as BaseNodeData;
 			break;


### PR DESCRIPTION
We use metadata to store properties related to types and predicates.
These are not directly graph properties. Still, we used to yield them
and the gui implementations was responsible for interpreting it and
change properties to all elements with the corresponding types or all edges
that used the corresponding predicate. This responsibility should be
moved to core and in this commit we solve the issue for predicates
(types are still remaining work)

An example is if a predicate is used twice resulting in two edges in the
corresponding graph. A new triple adding properties to the predicate
(using the predicate as subject) will result in 2 properties yielded to
the gui implementation. This brings us one step closer to the dream of
our gui implementation only implementing an interface with simple
methods like:

AddNode(<id>)
AddEdge(<id>)
AddProperty(<node- or edgeid>, <key>, <value>)
RemoveNode(<id>)
...

Added a new test strategy in src/core/tests/patchGraph/testUtils.ts. We
use simplified assertions to match against the actual assertions yielded
from patchGraph to check that we receive the edge-, node- or
property-assertions in the right order. We do not inspect more content
opening some possibilities for bugs, but these tests with this
abstraction has proven to be useful.

Modified cygraph storywrapper to further tests the new functionality.
Has not yet been tested in the other GUI implementation other than not
breaking existing stories.