### PR TITLE
feat: add error handling

### DIFF
--- a/src/core/components/RdfGraphHoc.tsx
+++ b/src/core/components/RdfGraphHoc.tsx
@@ -8,7 +8,13 @@ import { RdfStateProps } from '../state/RdfState.types';
 export function createRdfGraphHoc<P extends GraphProps, R = Omit<P, keyof GraphProps>>(
 	Component: FC<P>
 ): FC<R & RdfStateProps> {
-	return ({ rdfStore: _rdfStore, rdfPatch, selectionEffect, ...props }: RdfStateProps) => {
+	return ({
+		rdfStore: _rdfStore,
+		rdfPatch,
+		selectionEffect,
+		onErrorCallback,
+		...props
+	}: RdfStateProps) => {
 		const prevSelectionEffect = useRef<PropertyAssertion[]>([]);
 		const forwardSelection = (selection: GraphSelection) => {
 			if (!selectionEffect) return [];
@@ -38,7 +44,11 @@ export function createRdfGraphHoc<P extends GraphProps, R = Omit<P, keyof GraphP
 			update(newGraphState);
 		}, [rdfPatch]);
 
-		return <Component {...({ ...state, ...props, selectionEffect: forwardSelection } as P)} />;
+		return (
+			<Component
+				{...({ ...state, ...props, onErrorCallback, selectionEffect: forwardSelection } as P)}
+			/>
+		);
 	};
 }
 

--- a/src/core/state/GraphStateProps.tsx
+++ b/src/core/state/GraphStateProps.tsx
@@ -1,4 +1,5 @@
 import { GraphPatch, GraphState, SelectionCallback } from '../types/graphModel';
+import { RdfGraphError } from './RdfState.types';
 
 export type GraphStateProps = {
 	graphState: GraphState;
@@ -9,4 +10,5 @@ export type GraphProps = {
 	graphState: GraphState;
 	graphPatch: GraphPatch;
 	selectionEffect: SelectionCallback;
+	onErrorCallback?: (error: RdfGraphError) => void;
 };

--- a/src/core/state/RdfState.types.ts
+++ b/src/core/state/RdfState.types.ts
@@ -1,4 +1,4 @@
-import { RdfPatch2 } from '../types';
+import { GraphAssertion, RdfPatch2 } from '../types';
 import { Store, Quad } from 'n3';
 import { SelectionCallback } from '../types/graphModel';
 import { UiNodeSymbol } from '../ui/applyPatch';
@@ -8,14 +8,34 @@ export type RdfAction =
 	| { type: 'remove'; data: Iterable<Quad> }
 	| { type: 'patch'; data: RdfPatch2 }
 	| { type: 'replace'; data: Iterable<Quad> }
-	| { type: 'clear' };
+	| { type: 'clear' }
+	| { type: 'reset' };
 
 export type RdfState = {
 	rdfStore: Store<Quad, Quad, Quad, Quad>;
 	rdfPatch: RdfPatch2;
 };
 
+export type RdfGraphErrorBase = {
+	message: string;
+	/** 'error' from a try/catch block */
+	origin?: unknown;
+};
+
+export type GenericError = RdfGraphErrorBase & {
+	type: 'GENERIC';
+};
+
+export type GraphAssertionError = RdfGraphErrorBase & {
+	type: 'ASSERTION';
+	assertion?: GraphAssertion;
+};
+
+export type RdfGraphError = GenericError | GraphAssertionError;
+
+//assertion: GraphAssertion;
 export type RdfStateProps = RdfState & {
 	selectionEffect?: SelectionCallback;
 	symbolProvider?: (id: string, rotation?: number) => UiNodeSymbol | undefined;
+	onErrorCallback?: (error: RdfGraphError) => void;
 };

--- a/src/core/state/useRdfState.ts
+++ b/src/core/state/useRdfState.ts
@@ -74,6 +74,11 @@ const reducer: (state: RdfState, action: RdfAction) => RdfState = (state, action
 				rdfStore: new Store<Quad, Quad, Quad, Quad>(),
 				rdfPatch: clearing,
 			};
+		case 'reset':
+			return {
+				rdfStore: new Store<Quad, Quad, Quad, Quad>(),
+				rdfPatch: [],
+			};
 	}
 };
 

--- a/src/core/ui/applyAssertion.ts
+++ b/src/core/ui/applyAssertion.ts
@@ -1,0 +1,80 @@
+import { GraphAssertion } from '../types';
+import {
+	IUiPatchHandler,
+	UiNodePatchProperties,
+	UiConnectorPatchProperties,
+	UiEdgePatchProperties,
+} from './applyPatch';
+
+export function applyAssertion(ui: IUiPatchHandler, { action, assertion }: GraphAssertion) {
+	switch (assertion.type) {
+		case 'node':
+			if (action === 'add') ui.addNode(assertion.id);
+			else ui.removeNode(assertion.id);
+			break;
+		case 'edge':
+			if (action === 'add')
+				ui.addEdge({
+					edgeId: assertion.id,
+					fromNode: assertion.source,
+					fromConnector: assertion.sourceConnector,
+					toNode: assertion.target,
+					toConnector: assertion.targetConnector,
+				});
+			else ui.removeEdge(assertion.id);
+			break;
+		case 'connector':
+			if (action === 'add') ui.addConnector(assertion.id, assertion.node.id);
+			else ui.removeNode(assertion.id);
+			break;
+		case 'property':
+			switch (assertion.target.type) {
+				case 'node':
+					if (action === 'add')
+						ui.addNodeProperty(
+							assertion.target.id,
+							assertion.key as keyof UiNodePatchProperties,
+							assertion.value
+						);
+					else
+						ui.removeNodeProperty(
+							assertion.target.id,
+							assertion.key as keyof UiNodePatchProperties
+						);
+					break;
+				case 'connector':
+					if (action === 'add')
+						ui.addConnectorProperty(
+							assertion.target.id,
+							assertion.target.node.id,
+							assertion.key as keyof UiConnectorPatchProperties,
+							assertion.value
+						);
+					else
+						ui.removeConnectorProperty(
+							assertion.target.id,
+							assertion.target.node.id,
+							assertion.key as keyof UiConnectorPatchProperties
+						);
+					break;
+				case 'edge':
+					if (action === 'add')
+						ui.addEdgeProperty(
+							assertion.target.id,
+							assertion.key as keyof UiEdgePatchProperties,
+							assertion.value
+						);
+					else
+						ui.removeEdgeProperty(
+							assertion.target.id,
+							assertion.key as keyof UiEdgePatchProperties
+						);
+					break;
+				default:
+					break;
+			}
+			break;
+		default:
+			break;
+	}
+}

--- a/src/core/ui/applyPatch.ts
+++ b/src/core/ui/applyPatch.ts
@@ -136,7 +136,6 @@ export function applyPatch(graphPatch: GraphPatch, ui: IUiPatchHandler): void {
 	}
 
 	if (patchError) {
-		//ui.onPatchError.call(ui, patchError);
 		ui.onPatchError(patchError);
 	}
 

--- a/src/core/ui/applyPatch.ts
+++ b/src/core/ui/applyPatch.ts
@@ -1,4 +1,5 @@
 import { GraphAssertion, GraphPatch } from '../types';
+import { applyAssertion } from './applyAssertion';
 
 export type Point = { x: number; y: number };
 
@@ -114,78 +115,9 @@ export function applyPatch(graphPatch: GraphPatch, ui: IUiPatchHandler): void {
 	let currentAssertion: GraphAssertion | undefined;
 
 	try {
-		for (const { action, assertion } of graphPatch) {
-			currentAssertion = { action, assertion };
-			switch (assertion.type) {
-				case 'node':
-					if (action === 'add') ui.addNode(assertion.id);
-					else ui.removeNode(assertion.id);
-					break;
-				case 'edge':
-					if (action === 'add')
-						ui.addEdge({
-							edgeId: assertion.id,
-							fromNode: assertion.source,
-							fromConnector: assertion.sourceConnector,
-							toNode: assertion.target,
-							toConnector: assertion.targetConnector,
-						});
-					else ui.removeEdge(assertion.id);
-					break;
-				case 'connector':
-					if (action === 'add') ui.addConnector(assertion.id, assertion.node.id);
-					else ui.removeNode(assertion.id);
-					break;
-				case 'property':
-					switch (assertion.target.type) {
-						case 'node':
-							if (action === 'add')
-								ui.addNodeProperty(
-									assertion.target.id,
-									assertion.key as keyof UiNodePatchProperties,
-									assertion.value
-								);
-							else
-								ui.removeNodeProperty(
-									assertion.target.id,
-									assertion.key as keyof UiNodePatchProperties
-								);
-							break;
-						case 'connector':
-							if (action === 'add')
-								ui.addConnectorProperty(
-									assertion.target.id,
-									assertion.target.node.id,
-									assertion.key as keyof UiConnectorPatchProperties,
-									assertion.value
-								);
-							else
-								ui.removeConnectorProperty(
-									assertion.target.id,
-									assertion.target.node.id,
-									assertion.key as keyof UiConnectorPatchProperties
-								);
-							break;
-						case 'edge':
-							if (action === 'add')
-								ui.addEdgeProperty(
-									assertion.target.id,
-									assertion.key as keyof UiEdgePatchProperties,
-									assertion.value
-								);
-							else
-								ui.removeEdgeProperty(
-									assertion.target.id,
-									assertion.key as keyof UiEdgePatchProperties
-								);
-							break;
-						default:
-							break;
-					}
-					break;
-				default:
-					break;
-			}
+		for (const assertion of graphPatch) {
+			currentAssertion = assertion;
+			applyAssertion(ui, assertion);
 		}
 	} catch (error) {
 		let message;
@@ -204,7 +136,8 @@ export function applyPatch(graphPatch: GraphPatch, ui: IUiPatchHandler): void {
 	}
 
 	if (patchError) {
-		ui.onPatchError.call(ui, patchError);
+		//ui.onPatchError.call(ui, patchError);
+		ui.onPatchError(patchError);
 	}
 
 	ui.onAfterApplyPatch?.call(ui);

--- a/src/core/ui/applyPatch.ts
+++ b/src/core/ui/applyPatch.ts
@@ -1,4 +1,4 @@
-import { GraphPatch } from '../types';
+import { GraphAssertion, GraphPatch } from '../types';
 
 export type Point = { x: number; y: number };
 
@@ -61,6 +61,12 @@ export interface UiNodeConnector {
 	position: Point | 'Left' | 'Right' | 'Top' | 'Bottom';
 }
 
+export type PatchError = Readonly<{
+	message: string;
+	error: unknown;
+	assertion?: GraphAssertion;
+}>;
+
 export interface IUiPatchHandler {
 	addNode(id: string): void;
 	removeNode(id: string): void;
@@ -94,6 +100,8 @@ export interface IUiPatchHandler {
 	): void;
 	removeEdgeProperty<P extends keyof UiEdgePatchProperties>(edgeId: string, prop: P): void;
 
+	onPatchError: (error: PatchError) => void;
+
 	onBeforeApplyPatch?: () => void;
 	onAfterApplyPatch?: () => void;
 }
@@ -102,77 +110,101 @@ export interface IUiPatchHandler {
 export function applyPatch(graphPatch: GraphPatch, ui: IUiPatchHandler): void {
 	ui.onBeforeApplyPatch?.call(ui);
 
-	for (const { action, assertion } of graphPatch) {
-		switch (assertion.type) {
-			case 'node':
-				if (action === 'add') ui.addNode(assertion.id);
-				else ui.removeNode(assertion.id);
-				break;
-			case 'edge':
-				if (action === 'add')
-					ui.addEdge({
-						edgeId: assertion.id,
-						fromNode: assertion.source,
-						fromConnector: assertion.sourceConnector,
-						toNode: assertion.target,
-						toConnector: assertion.targetConnector,
-					});
-				else ui.removeEdge(assertion.id);
-				break;
-			case 'connector':
-				if (action === 'add') ui.addConnector(assertion.id, assertion.node.id);
-				else ui.removeNode(assertion.id);
-				break;
-			case 'property':
-				switch (assertion.target.type) {
-					case 'node':
-						if (action === 'add')
-							ui.addNodeProperty(
-								assertion.target.id,
-								assertion.key as keyof UiNodePatchProperties,
-								assertion.value
-							);
-						else
-							ui.removeNodeProperty(
-								assertion.target.id,
-								assertion.key as keyof UiNodePatchProperties
-							);
-						break;
-					case 'connector':
-						if (action === 'add')
-							ui.addConnectorProperty(
-								assertion.target.id,
-								assertion.target.node.id,
-								assertion.key as keyof UiConnectorPatchProperties,
-								assertion.value
-							);
-						else
-							ui.removeConnectorProperty(
-								assertion.target.id,
-								assertion.target.node.id,
-								assertion.key as keyof UiConnectorPatchProperties
-							);
-						break;
-					case 'edge':
-						if (action === 'add')
-							ui.addEdgeProperty(
-								assertion.target.id,
-								assertion.key as keyof UiEdgePatchProperties,
-								assertion.value
-							);
-						else
-							ui.removeEdgeProperty(
-								assertion.target.id,
-								assertion.key as keyof UiEdgePatchProperties
-							);
-						break;
-					default:
-						return;
-				}
-				break;
-			default:
-				break;
+	let patchError: PatchError | null = null;
+	let currentAssertion: GraphAssertion | undefined;
+
+	try {
+		for (const { action, assertion } of graphPatch) {
+			currentAssertion = { action, assertion };
+			switch (assertion.type) {
+				case 'node':
+					if (action === 'add') ui.addNode(assertion.id);
+					else ui.removeNode(assertion.id);
+					break;
+				case 'edge':
+					if (action === 'add')
+						ui.addEdge({
+							edgeId: assertion.id,
+							fromNode: assertion.source,
+							fromConnector: assertion.sourceConnector,
+							toNode: assertion.target,
+							toConnector: assertion.targetConnector,
+						});
+					else ui.removeEdge(assertion.id);
+					break;
+				case 'connector':
+					if (action === 'add') ui.addConnector(assertion.id, assertion.node.id);
+					else ui.removeNode(assertion.id);
+					break;
+				case 'property':
+					switch (assertion.target.type) {
+						case 'node':
+							if (action === 'add')
+								ui.addNodeProperty(
+									assertion.target.id,
+									assertion.key as keyof UiNodePatchProperties,
+									assertion.value
+								);
+							else
+								ui.removeNodeProperty(
+									assertion.target.id,
+									assertion.key as keyof UiNodePatchProperties
+								);
+							break;
+						case 'connector':
+							if (action === 'add')
+								ui.addConnectorProperty(
+									assertion.target.id,
+									assertion.target.node.id,
+									assertion.key as keyof UiConnectorPatchProperties,
+									assertion.value
+								);
+							else
+								ui.removeConnectorProperty(
+									assertion.target.id,
+									assertion.target.node.id,
+									assertion.key as keyof UiConnectorPatchProperties
+								);
+							break;
+						case 'edge':
+							if (action === 'add')
+								ui.addEdgeProperty(
+									assertion.target.id,
+									assertion.key as keyof UiEdgePatchProperties,
+									assertion.value
+								);
+							else
+								ui.removeEdgeProperty(
+									assertion.target.id,
+									assertion.key as keyof UiEdgePatchProperties
+								);
+							break;
+						default:
+							break;
+					}
+					break;
+				default:
+					break;
+			}
 		}
+	} catch (error) {
+		let message;
+
+		if (error instanceof Error) {
+			message = error.message;
+		} else {
+			message = String(error);
+		}
+
+		patchError = {
+			assertion: currentAssertion,
+			message,
+			error,
+		};
+	}
+
+	if (patchError) {
+		ui.onPatchError.call(ui, patchError);
 	}
 
 	ui.onAfterApplyPatch?.call(ui);

--- a/src/goGraph/components/goGraph/GoGraph.tsx
+++ b/src/goGraph/components/goGraph/GoGraph.tsx
@@ -19,7 +19,9 @@ export const GoGraph: FC<GoGraphProps> = (props) => {
 
 	const diagramRef = useRef<go.Diagram>(initDiagram());
 
-	const patchHandlerRef = useRef<IUiPatchHandler>(new GoJsPatchHandler(diagramRef.current));
+	const patchHandlerRef = useRef<IUiPatchHandler>(
+		new GoJsPatchHandler(diagramRef.current, props.onErrorCallback)
+	);
 
 	useEffect(() => {
 		applyPatch(props.graphPatch, patchHandlerRef.current);

--- a/src/goGraph/storybook/StoryWrapper.tsx
+++ b/src/goGraph/storybook/StoryWrapper.tsx
@@ -11,6 +11,7 @@ import { getConnectorSymbol, SymbolLibraryKey } from '../../symbol-api';
 import { UiNodeSymbol } from '../../core/ui/applyPatch';
 import { ConnectorSymbolToUiNodeSymbol } from '../../core/ui/defaultSymbolProvider';
 import { defaultInitDiagram } from '../components/goGraph/defaultInit';
+import { RdfGraphError } from '../../core';
 
 export type GoStoryWrapperProps = {
 	turtleString: string;
@@ -57,6 +58,12 @@ export const StoryWrapper = ({ turtleString, selectionEffect }: GoStoryWrapperPr
 		model.setDataProperty(model.modelData, 'portOpacity', showSymbolPorts ? 1 : 0);
 	}, [showSymbolPorts]);
 
+	const rdfGraphErrorHandler = (error: RdfGraphError) => {
+		console.log('RdfGraphError: ', error);
+		diagramRef.current.clear();
+		dispatch({ type: 'reset' });
+	};
+
 	return (
 		<div>
 			<Button onClick={loadTurtle}>Load turtle</Button>
@@ -70,6 +77,7 @@ export const StoryWrapper = ({ turtleString, selectionEffect }: GoStoryWrapperPr
 				containerStyle={diagramStyle}
 				symbolProvider={symbolProviderJson}
 				selectionEffect={handleSelection}
+				onErrorCallback={rdfGraphErrorHandler}
 			/>
 		</div>
 	);

--- a/src/goGraph/uiPatchHandler.ts
+++ b/src/goGraph/uiPatchHandler.ts
@@ -1,6 +1,9 @@
 import * as go from 'gojs';
+import { RdfGraphError } from '../core';
+
 import {
 	IUiPatchHandler,
+	PatchError,
 	Point,
 	UiConnectorPatchProperties,
 	UiEdge,
@@ -42,7 +45,10 @@ const connectorPropMap: Record<keyof UiConnectorPatchProperties, string> = {
 export class GoJsPatchHandler implements IUiPatchHandler {
 	#zoomToFitTimeout: NodeJS.Timeout | null = null;
 	#initialPatchBurst: 'READY' | 'RECEIVING' | 'DONE' = 'READY';
-	constructor(readonly diagram: go.Diagram) {}
+	constructor(
+		readonly diagram: go.Diagram,
+		readonly onErrorCallback?: (error: RdfGraphError) => void
+	) {}
 
 	addNode(id: string): void {
 		const n: BaseNodeData = {
@@ -213,6 +219,19 @@ export class GoJsPatchHandler implements IUiPatchHandler {
 		}
 
 		this.diagram.model.setDataProperty(linkData, edgePropKey, newValue);
+	}
+
+	onPatchError(error: PatchError) {
+		if (this.onErrorCallback !== undefined) {
+			this.onErrorCallback.call(undefined, {
+				type: 'ASSERTION',
+				message: error.message,
+				assertion: error.assertion,
+				origin: error.error,
+			});
+		} else {
+			console.error('RdfGraph Assertion Error:', error);
+		}
 	}
 
 	onBeforeApplyPatch() {

--- a/src/goGraph/uiPatchHandler.ts
+++ b/src/goGraph/uiPatchHandler.ts
@@ -162,12 +162,13 @@ export class GoJsPatchHandler implements IUiPatchHandler {
 	}
 
 	removeConnectorProperty<P extends keyof UiConnectorPatchProperties>(
-		id: string,
-		nodeId: string,
-		prop: P
+		_id: string,
+		_nodeId: string,
+		_prop: P
 	): void {
-		console.warn('<removeConnectorProperty> not implemented.');
-		console.warn(`id: ${id}, nodeId: ${nodeId}, prop: ${prop}`);
+		// May log this stuff to future logger
+		// console.warn('<removeConnectorProperty> not implemented.');
+		// console.warn(`id: ${id}, nodeId: ${nodeId}, prop: ${prop}`);
 	}
 
 	addEdge(edge: UiEdge): void {


### PR DESCRIPTION
Add system for catching errors and providing a callback for users of an UI implementation to handle errors.

Currently only patch assertion errors are invoked (caused system meltdown in "playground").

This feature prevents total crash and the possibility to reset GoJS and state, but more importantly it helps us to debug:
https://github.com/equinor/rdf-graph/blob/633640287c43767b161a3387acd4a35d52071479/src/core/state/patchGraph.ts#L323