### PR TITLE
feat: hasParent predicate and gojs groups

### DIFF
--- a/src/core/mapper/predicates.ts
+++ b/src/core/mapper/predicates.ts
@@ -3,7 +3,7 @@ import { TwoWayMap } from '../utils';
 
 const { namedNode } = DataFactory;
 
-export const compoundNodeIri = 'http://rdf.equinor.com/ui/parent';
+export const hasParentIri = 'http://rdf.equinor.com/ui/hasParent';
 export const labelIri = 'http://www.w3.org/2000/01/rdf-schema#label';
 export const colorIri = 'http://rdf.equinor.com/ui/color';
 export const hasConnectorIri = 'http://rdf.equinor.com/ui/hasConnector';
@@ -17,7 +17,7 @@ export const hasDirectionIri = 'http://rdf.equinor.com/ui/hasDirection';
 export const typeIri = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 
 // keys linked to predicates
-export const compoundNodeKey = 'parent';
+export const parentKey = 'parent';
 export const labelKey = 'label';
 export const colorKey = 'color';
 export const svgKey = 'svgId';
@@ -34,7 +34,7 @@ export const connectorNameKey = 'connectorName';
 export const connectorDirectionKey = 'connectorDirection';
 export const connectorRelativePositionKey = 'connectorRelativePosition';
 
-export const compoundNodePredicate = namedNode(compoundNodeIri);
+export const hasParentPredicate = namedNode(hasParentIri);
 export const labelPredicate = namedNode(labelIri);
 export const colorPredicate = namedNode(colorIri);
 export const hasConnectorPredicate = namedNode(hasConnectorIri);
@@ -44,7 +44,7 @@ export const hasConnectorSuffixPredicate = namedNode(hasConnectorSuffixIri);
 export const rotationPredicate = namedNode(rotationIri);
 
 const dict: { [key: string]: string } = {
-	[compoundNodeIri]: compoundNodeKey,
+	[hasParentIri]: parentKey,
 	[labelIri]: labelKey,
 	[colorIri]: colorKey,
 	[hasSimpleSvgIri]: simpleSvgKey,
@@ -60,7 +60,7 @@ export const imageHeightKey = 'imageHeight';
 export const relativePositionXKey = 'relativePositionX';
 export const relativePositionYKey = 'relativePositionY';
 
-export const parentPredicates = [compoundNodeIri];
+export const parentPredicates = [hasParentIri];
 export const childPredicates = [hasConnectorIri];
 
 export const predicateMap = new TwoWayMap(dict);

--- a/src/core/tests/patchGraph/patchOrder.test.tsx
+++ b/src/core/tests/patchGraph/patchOrder.test.tsx
@@ -40,7 +40,7 @@ test('Node becomes connector and node again', () => {
 	];
 
 	const expectedRmOrder: SimplifiedAssertion[] = [
-		{ type: 'property', action: 'remove' }, // Lable
+		{ type: 'property', action: 'remove' }, // Label
 		{ type: 'property', action: 'remove' }, // Connector id
 		{ type: 'property', action: 'remove' }, // connectorRelativePosition
 		{ type: 'property', action: 'remove' }, // connectorDirection

--- a/src/core/ui/applyAssertion.ts
+++ b/src/core/ui/applyAssertion.ts
@@ -25,7 +25,7 @@ export function applyAssertion(ui: IUiPatchHandler, { action, assertion }: Graph
 			break;
 		case 'connector':
 			if (action === 'add') ui.addConnector(assertion.id, assertion.node.id);
-			else ui.removeNode(assertion.id);
+			else ui.removeConnector(assertion.id, assertion.node.id);
 			break;
 		case 'property':
 			switch (assertion.target.type) {

--- a/src/core/ui/applyPatch.ts
+++ b/src/core/ui/applyPatch.ts
@@ -1,4 +1,4 @@
-import { GraphAssertion, GraphPatch } from '../types';
+import { GraphAssertion, GraphNode, GraphPatch } from '../types';
 import { applyAssertion } from './applyAssertion';
 
 export type Point = { x: number; y: number };
@@ -6,6 +6,7 @@ export type Point = { x: number; y: number };
 export type UiNodeShape = 'Circle' | 'Square';
 
 export interface UiNodePatchProperties {
+	parent: GraphNode;
 	backgroundColor: string;
 	borderColor: string;
 	highlightBorderColor: string;
@@ -18,6 +19,7 @@ export interface UiNodePatchProperties {
 	symbolWidth: number;
 	symbolHeight: number;
 	symbolGeometry: string;
+	isGroup: boolean;
 }
 
 export interface UiEdge {

--- a/src/goGraph/components/goGraph/defaultInit.ts
+++ b/src/goGraph/components/goGraph/defaultInit.ts
@@ -1,4 +1,5 @@
 import * as go from 'gojs';
+import { createDefaultGroupTemplate } from '../../templates/default-group-template';
 import { createDefaultLinkTemplate } from '../../templates/default-link-template';
 import { createDefaultNodeTemplate } from '../../templates/default-node-template';
 import { createSymbolNodeTemplate } from '../../templates/symbol-node-template';
@@ -27,6 +28,7 @@ export function defaultInitDiagram() {
 			.add(NodeUiCategory.Default, createDefaultNodeTemplate(clickHandler))
 			.add(NodeUiCategory.ConnectorSymbol, createSymbolNodeTemplate(symbolNodeClickHandler)),
 		linkTemplateMap: new go.Map<string, go.Link>().add('', createDefaultLinkTemplate()),
+		groupTemplate: createDefaultGroupTemplate(),
 	});
 
 	d.toolManager.rotatingTool.snapAngleMultiple = 45;

--- a/src/goGraph/storybook/GoGraph.stories.tsx
+++ b/src/goGraph/storybook/GoGraph.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { GoStoryWrapperProps, StoryWrapper } from './StoryWrapper';
 
 import { martinsTurtle } from './data/martins_verden_turtle';
+import { systems_ttl } from './data/systems_ttl';
 import { connectorSymbols_ttl } from './data/connectorSymbols_ttl';
 import { GoGraph } from '../components/goGraph/GoGraph';
 
@@ -33,3 +34,9 @@ connectorSymbols.args = {
 	turtleString: connectorSymbols_ttl,
 } as GoStoryWrapperProps;
 connectorSymbols.storyName = `Connector symbols`;
+
+export const systems = Template.bind({});
+systems.args = {
+	turtleString: systems_ttl,
+} as GoStoryWrapperProps;
+systems.storyName = `Grouping`;

--- a/src/goGraph/storybook/data/systems_ttl.ts
+++ b/src/goGraph/storybook/data/systems_ttl.ts
@@ -1,0 +1,141 @@
+export const systems_ttl = `
+@prefix equinor:        <https://rdf.equinor.com/> .
+@prefix equipment:      <https://rdf.equinor.com/ontology/equipment/v1#> .
+@prefix identification: <https://rdf.equinor.com/ontology/facility-identification/v1#> .
+@prefix identifier:     <https://rdf.equinor.com/data/facility-identification/> .
+@prefix linelist:       <https://rdf.equinor.com/ontology/linelist/v1#> .
+@prefix mel:            <https://rdf.equinor.com/source/mel#> .
+@prefix owl:            <http://www.w3.org/2002/07/owl#> .
+@prefix pca:            <https://rdf.equinor.com/ontology/pca#> .
+@prefix physical:       <https://rdf.equinor.com/ontology/physical/v1#> .
+@prefix prov:           <http://www.w3.org/ns/prov#> .
+@prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sor:            <https://rdf.equinor.com/ontology/sor#> .
+@prefix source:         <https://rdf.equinor.com/source/> .
+@prefix tag:            <https://rdf.equinor.com/ontology/tag/v1#> .
+@prefix transformation: <https://rdf.equinor.com/ontology/transformation#> .
+@prefix ui:             <http://rdf.equinor.com/ui/> .
+@prefix uom:            <https://rdf.equinor.com/ontology/uom/v1#> .
+@prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/systems#82>
+        rdfs:label  "82" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systemGroup#morethan50>
+        rdfs:label  "morethan50" .
+
+<http://example.org/systems#00>
+        rdfs:label  "00" ;
+        ui:hasParent   <http://example.org/systemGroup#0-19> .
+
+<http://example.org/systems#87>
+        rdfs:label  "87" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#43>
+        rdfs:label  "43" ;
+        ui:hasParent   <http://example.org/systemGroup#40-49> .
+
+<http://example.org/systems#77>
+        rdfs:label  "77" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#24>
+        rdfs:label  "24" ;
+        ui:hasParent   <http://example.org/systemGroup#20-29> .
+
+<http://example.org/systems#86>
+        rdfs:label  "86" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#80>
+        rdfs:label  "80" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systemGroup#0-19>
+        rdfs:label  "0-19" .
+
+<http://example.org/systems#42>
+        rdfs:label  "42" ;
+        ui:hasParent   <http://example.org/systemGroup#40-49> .
+
+<http://example.org/systems#70>
+        rdfs:label  "70" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#76>
+        rdfs:label  "76" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#85>
+        rdfs:label  "85" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systemGroup#20-29>
+        rdfs:label  "20-29" .
+
+<http://example.org/systems#41>
+        rdfs:label  "41" ;
+        ui:hasParent   <http://example.org/systemGroup#40-49> .
+
+<http://example.org/systems#47>
+        rdfs:label  "47" ;
+        ui:hasParent   <http://example.org/systemGroup#40-49> .
+
+<http://example.org/systems#50>
+        rdfs:label  "50" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#56>
+        rdfs:label  "56" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#18>
+        rdfs:label  "18" ;
+        ui:hasParent   <http://example.org/systemGroup#0-19> .
+
+<http://example.org/systems#74>
+        rdfs:label  "74" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systemGroup#40-49>
+        rdfs:label  "40-49" .
+
+<http://example.org/systems#27>
+        rdfs:label  "27" ;
+        ui:hasParent   <http://example.org/systemGroup#20-29> .
+
+<http://example.org/systems#55>
+        rdfs:label  "55" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#83>
+        rdfs:label  "83" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#64>
+        rdfs:label  "64" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#92>
+        rdfs:label  "92" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#79>
+        rdfs:label  "79" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#73>
+        rdfs:label  "73" ;
+        ui:hasParent   <http://example.org/systemGroup#morethan50> .
+
+<http://example.org/systems#20>
+        rdfs:label  "20" ;
+        ui:hasParent   <http://example.org/systemGroup#20-29> .
+
+<http://example.org/systems#26>
+        rdfs:label  "26" ;
+        ui:hasParent   <http://example.org/systemGroup#20-29> .
+`;

--- a/src/goGraph/templates/default-group-template.ts
+++ b/src/goGraph/templates/default-group-template.ts
@@ -1,0 +1,28 @@
+import * as go from 'gojs';
+
+export function createDefaultGroupTemplate(): go.Group {
+	const $ = go.GraphObject.make;
+
+	return $(
+		go.Group,
+		'Vertical',
+		$(
+			go.Panel,
+			'Auto',
+			$(
+				go.Shape,
+				'RoundedRectangle', // surrounds the Placeholder
+				{ parameter1: 14, fill: 'rgba(128,128,128,0.33)' }
+			),
+			$(
+				go.Placeholder, // represents the area of all member parts,
+				{ padding: 5 }
+			) // with some extra padding around them
+		),
+		$(
+			go.TextBlock, // group title
+			{ alignment: go.Spot.Right, font: 'Bold 12pt Sans-Serif' },
+			new go.Binding('text', 'label')
+		)
+	);
+}

--- a/src/goGraph/types/goNode.types.ts
+++ b/src/goGraph/types/goNode.types.ts
@@ -30,6 +30,7 @@ export type BaseNodeData = {
 	symbolHeight?: number;
 	symbolWidth?: number;
 	symbolConnectors?: SymbolConnector[];
+	isGroup?: boolean;
 };
 
 export type PortData = {

--- a/src/symbol-api/storybook/symbol-api.stories.tsx
+++ b/src/symbol-api/storybook/symbol-api.stories.tsx
@@ -57,7 +57,7 @@ function getSymbolsTurtle(): string {
 		}
 	}
 
-	console.log(turtle);
+	//console.log(turtle);
 
 	return turtle;
 }


### PR DESCRIPTION
- Add ui:hasParent predicate logic (yield property isGroup instead of edge)
- Use "parent" and "isGroup" prop in gojs patch handler to render group

"group"/"the parent" has not been implemented like nodes and connectors.

This PR/solution should be considered as a temporary solution.