### PR TITLE
chore: remove nodes when empty

### DIFF
--- a/src/core/baseGraphOperations.ts
+++ b/src/core/baseGraphOperations.ts
@@ -105,11 +105,16 @@ export function createEdgeChange(
 			targetId: targetId,
 		};
 
+		const newEdgeStore =
+			action === 'add'
+				? { ...state.graphState.edgeStore, [edgeId]: newEdge }
+				: deleteEntriesFromRecord(state.graphState.edgeStore, [edgeId]);
+
 		return new PatchGraphMonad({
 			...state,
 			graphState: {
 				...state.graphState,
-				edgeStore: { ...state.graphState.edgeStore, [edgeId]: newEdge },
+				edgeStore: newEdgeStore,
 			},
 			graphPatches: [...state.graphPatches, { action: action, content: newEdge }],
 		});

--- a/src/core/complexGraphOperations.ts
+++ b/src/core/complexGraphOperations.ts
@@ -333,10 +333,9 @@ export function createNewNode(
 }
 
 function isEmpty(node: GraphNode, edges: GraphEdge[]) {
-	return (
-		node.props.length === 0 &&
-		edges.find((e) => e.sourceId === node.id || e.targetId === node.id) === undefined
-	);
+	const noProps = node.props.length === 0;
+	const hasEdges = edges.some((e) => e.sourceId === node.id || e.targetId === node.id)
+	return noProps && !hasEdges;
 }
 
 // Ignoring IRI objects when adding props except for connectorId which should be treated as a property

--- a/src/core/complexGraphOperations.ts
+++ b/src/core/complexGraphOperations.ts
@@ -334,7 +334,7 @@ export function createNewNode(
 
 function isEmpty(node: GraphNode, edges: GraphEdge[]) {
 	const noProps = node.props.length === 0;
-	const hasEdges = edges.some((e) => e.sourceId === node.id || e.targetId === node.id)
+	const hasEdges = edges.some((e) => e.sourceId === node.id || e.targetId === node.id);
 	return noProps && !hasEdges;
 }
 

--- a/src/core/patch.ts
+++ b/src/core/patch.ts
@@ -1,5 +1,6 @@
 import {
 	applyRules,
+	cleanEmptyNodes,
 	ensureEdgeRemoved,
 	ensureObjectNode,
 	ensurePredicateNodeWithEdge,
@@ -47,7 +48,11 @@ function rdfToGraphPatch(rdfPatches: RdfPatch[], options: PatchGraphOptions): Bi
 					ensurePredicatePropAdded(rdfPatch)
 				);
 			} else {
-				bindings.push(ensurePredicatePropRemoved(rdfPatch), ensureEdgeRemoved(rdfPatch));
+				bindings.push(
+					ensurePredicatePropRemoved(rdfPatch),
+					ensureEdgeRemoved(rdfPatch),
+					cleanEmptyNodes(rdfPatch)
+				);
 			}
 			bindings.push(applyRules(rdfPatch, options));
 			return acc.bindMany(bindings);

--- a/src/core/tests/removal.test.ts
+++ b/src/core/tests/removal.test.ts
@@ -1,0 +1,38 @@
+import {
+	createChangePatches,
+	simpleEdge,
+	simpleProp,
+	testNode1,
+	testNode2,
+	toRemovePatch,
+} from './test-utils';
+
+describe('Remove node when references are gone', () => {
+	it('Remove node when removing literal', () => {
+		const patches = createChangePatches([simpleProp], toRemovePatch([simpleProp]));
+
+		expect(patches.length).toBe(2);
+		expect(
+			patches.find(
+				(p) => p.action === 'remove' && p.content.type === 'node' && p.content.id === testNode1
+			)
+		).toBeTruthy();
+	});
+
+	it('Remove node when edges are gone', () => {
+		const patches = createChangePatches([simpleEdge], toRemovePatch([simpleEdge]));
+
+		expect(patches.length).toBe(3);
+
+		expect(
+			patches.find(
+				(p) => p.action === 'remove' && p.content.type === 'node' && p.content.id === testNode1
+			)
+		).toBeTruthy();
+		expect(
+			patches.find(
+				(p) => p.action === 'remove' && p.content.type === 'node' && p.content.id === testNode2
+			)
+		).toBeTruthy();
+	});
+});

--- a/src/core/tests/test-utils.ts
+++ b/src/core/tests/test-utils.ts
@@ -1,5 +1,6 @@
 import { GraphState, RdfPatch, UiSymbol, UiSymbolConnector, UiSymbolProvider } from '../types';
-import { Quad } from 'n3';
+import { DataFactory, Quad } from 'n3';
+import { patchGraphState } from '../patch';
 
 export function newGraphState(): GraphState {
 	return {
@@ -48,3 +49,18 @@ export const testSymbol: UiSymbol = {
 };
 
 export const testSymbolProvider: UiSymbolProvider = (_id, _rot) => testSymbol;
+
+export const createChangePatches = (original: Quad[], change: RdfPatch[]) => {
+	const state = newGraphState();
+	const oldPatches = toAddPatch(original);
+	const oldResult = patchGraphState(state, oldPatches);
+
+	return patchGraphState(oldResult.graphState, change).graphPatches;
+};
+
+const { quad: q, literal: l, namedNode: n } = DataFactory;
+
+export const testNode1 = 'A';
+export const testNode2 = 'B';
+export const simpleProp = q(n(testNode1), n('SomeDataProp'), l('someValue'));
+export const simpleEdge = q(n('A'), n('SomeDataProp'), n(testNode2));


### PR DESCRIPTION
When all properties and incoming / outgoing edges are removed, node should be removed as well