### PR TITLE
feat: add elementType to GraphPropertyPatch type

### DIFF
--- a/src/core/algorithms/algorithmEffects.ts
+++ b/src/core/algorithms/algorithmEffects.ts
@@ -10,6 +10,7 @@ export const highlightElement = (element: GraphElement): AlgorithmResult => {
 		id: element.id,
 		prop: { type: 'direct', key: 'fill', value: 'pink' },
 		type: 'property',
+		elementType: 'node',
 	};
 	const oldProp = element.props.find((p) => p.type === 'direct' && p.key === 'fill') as
 		| DirectProp
@@ -20,6 +21,7 @@ export const highlightElement = (element: GraphElement): AlgorithmResult => {
 			content: {
 				id: element.id,
 				type: 'property',
+				elementType: 'node',
 				prop: {
 					key: 'fill',
 					type: 'direct',
@@ -48,6 +50,7 @@ export const createSummary = (element: GraphElement, visited: string[]): Algorit
 					id: element.id,
 					prop: { type: 'direct', key: 'label', value: oldLabel },
 					type: 'property',
+					elementType: 'node',
 				},
 			});
 		}
@@ -62,6 +65,7 @@ export const createSummary = (element: GraphElement, visited: string[]): Algorit
 				id: element.id,
 				prop: { type: 'direct', key: 'label', value: newLabel },
 				type: 'property',
+				elementType: 'node',
 			},
 		});
 
@@ -75,6 +79,7 @@ export const createSummary = (element: GraphElement, visited: string[]): Algorit
 					id: element.id,
 					prop: { type: 'direct', key: 'fill', value: oldColor },
 					type: 'property',
+					elementType: 'node',
 				},
 			});
 		}
@@ -85,6 +90,7 @@ export const createSummary = (element: GraphElement, visited: string[]): Algorit
 				id: element.id,
 				prop: { type: 'direct', key: 'fill', value: 'yellow' },
 				type: 'property',
+				elementType: 'node',
 			},
 		});
 

--- a/src/core/baseGraphOperations.ts
+++ b/src/core/baseGraphOperations.ts
@@ -159,6 +159,7 @@ export function addProp(node: GraphNode, newProp: Prop): BindFunction {
 				content: {
 					id: node.id,
 					type: 'property',
+					elementType: 'node',
 					prop: {
 						...newProp,
 						value: Array.isArray(newProp.value) ? newProp.value[0] : newProp.value,
@@ -198,6 +199,7 @@ export function addPropToPredicateNode(nodeId: string, newProp: Prop): BindFunct
 				action: 'add',
 				content: {
 					type: 'property',
+					elementType: 'edge',
 					id: e,
 					prop: toPatchProp(newProp, value),
 				},
@@ -240,6 +242,7 @@ function createEdgePropPatches(
 				action: action,
 				content: {
 					type: 'property',
+					elementType: 'edge',
 					id: e,
 					prop,
 				},
@@ -275,6 +278,7 @@ export function deletePropFromNode(node: GraphNode, prop: Prop, value: unknown):
 					content: {
 						id: node.id,
 						type: 'property',
+						elementType: 'node',
 						prop: { key: prop.key, type: 'direct', value: value } as PatchDirectProp,
 					} as GraphPropertyPatch,
 				},
@@ -365,6 +369,7 @@ export function addEdgeProp(
 					action: 'add',
 					content: {
 						type: 'property',
+						elementType: 'edge',
 						id: edge.id,
 						prop: {
 							type: 'direct',
@@ -409,6 +414,7 @@ function createValueRemovalPatch(
 		content: {
 			id: nodeId,
 			type: 'property',
+			elementType: 'node',
 			prop: toPatchProp(prop, value),
 		},
 	};

--- a/src/core/types/core.ts
+++ b/src/core/types/core.ts
@@ -123,6 +123,7 @@ export type PatchProp = PatchDirectProp | DerivedProp | PatchCustomProp;
 
 export type GraphPropertyPatch = GraphPatchBase<'property'> & {
 	prop: PatchProp;
+	elementType: ElementType;
 };
 
 export interface GraphPatch {

--- a/src/go/applyPatch.ts
+++ b/src/go/applyPatch.ts
@@ -51,13 +51,24 @@ export function applyPatch(patches: GraphPatch[], diagram: go.Diagram, state: Rd
 				}
 				break;
 			case 'property':
-				if (patch.action === 'add') {
-					addEdgeProp(diagram, patch.content);
-					addNodeProp(diagram, state, patch.content);
-				} else {
-					removeNodeProp(diagram, patch.content);
+				switch (patch.content.elementType) {
+					case 'node':
+						if (patch.action === 'add') {
+							addNodeProp(diagram, state, patch.content);
+						} else {
+							removeNodeProp(diagram, patch.content);
+						}
+						break;
+					case 'edge':
+						if (patch.action === 'add') {
+							addEdgeProp(diagram, patch.content);
+						} else {
+							removeEdgeProp(diagram, patch.content);
+						}
+						break;
+					default:
+						break;
 				}
-
 				break;
 			default:
 				break;
@@ -248,9 +259,14 @@ function removeEdge(diagram: go.Diagram, edge: GraphEdge): void {
 
 function addEdgeProp(diagram: go.Diagram, propPatch: GraphPropertyPatch) {
 	const linkData = (diagram.model as go.GraphLinksModel).findLinkDataForKey(propPatch.id);
-
 	if (!linkData) return;
 	diagram.model.setDataProperty(linkData, propPatch.prop.key, propPatch.prop.value);
+}
+
+function removeEdgeProp(diagram: go.Diagram, propPatch: GraphPropertyPatch) {
+	const linkData = (diagram.model as go.GraphLinksModel).findLinkDataForKey(propPatch.id);
+	if (!linkData) return;
+	diagram.model.setDataProperty(linkData, propPatch.prop.key, undefined);
 }
 
 function addShadowConnector(


### PR DESCRIPTION
Adds field `elementType: ElementType;` to type `GraphPropertyPatch`. This allows easy handling of propert patches in UI implementations (applyPatch).