### PR TITLE
fix: custom property remove patch

### DIFF
--- a/dev/src/components/go/templates/pizza-node-template.ts
+++ b/dev/src/components/go/templates/pizza-node-template.ts
@@ -1,19 +1,17 @@
 import * as go from 'gojs';
 
-export function createPizzaNodeTemplate(
-	clickHandler?: (e: go.InputEvent, thisObj: go.GraphObject) => void
-): go.Node {
+export function createPizzaNodeTemplate(): go.Node {
 	return new go.Node(go.Panel.Vertical, {
 		resizable: false,
-		click: clickHandler,
+		click: () => console.info('You clicked on a pizza'),
 	})
 		.add(new go.Picture('/pizza.svg', { desiredSize: new go.Size(100, 100) }))
 		.add(
-			new go.TextBlock('<NoLabel>', {
+			new go.TextBlock('<NoLabel: use custom prop "pizzaName">', {
 				margin: 8,
 				wrap: go.TextBlock.WrapFit,
 				stroke: 'orange',
 				font: '20px "Comic Sans MS"',
-			}).bind('text', 'label')
+			}).bind('text', 'custom_pizzaName')
 		);
 }

--- a/dev/src/components/tab-edit/NodeItemDetails.tsx
+++ b/dev/src/components/tab-edit/NodeItemDetails.tsx
@@ -44,7 +44,6 @@ export const NodeItemDetails: React.FunctionComponent<{ node: GraphNode }> = ({ 
 	}, [graphContext.graphState.nodeStore, node.id]);
 
 	const dispatchProp = (action: 'add' | 'remove') => {
-		console.log(selectedPredicate);
 		const value = inputValueRef.current?.value;
 		if (!value || !selectedPredicate) return;
 

--- a/dev/src/components/tab-edit/TabEdit.tsx
+++ b/dev/src/components/tab-edit/TabEdit.tsx
@@ -256,6 +256,26 @@ export const TabEdit = () => {
 		...Object.keys(graphContext.graphState.nodeStore),
 	];
 
+	function convertToPizza() {
+		if (!selectedItem || selectedItem.type !== 'node') return;
+
+		const label = selectedItem.props.find((prop) => prop.key === 'label')?.value ?? '';
+
+		dispatch({
+			type: 'DispatchRdfPatches',
+			rdfPatches: [
+				{
+					action: 'add',
+					data: q(n(selectedItem.id), n(P.template.iri), l('pizza')),
+				},
+				{
+					action: 'add',
+					data: q(n(selectedItem.id), n('pizzaName'), l('Pepperoni with ' + label)),
+				},
+			],
+		});
+	}
+
 	useEffect(() => {
 		if (undoPatch) {
 			dispatch({
@@ -299,7 +319,12 @@ export const TabEdit = () => {
 					<Button onClick={() => addCluster()}>Add Cluster</Button>
 					<Button onClick={() => addTwoConnectedSymbolNodes()}>Add connected Symbols</Button>
 					<Button onClick={() => addCompleteSymbolLibrary()}>Add all symbols</Button>
-					<Button onClick={() => runBfs()}>Highlight connected nodes</Button>
+					<Button onClick={() => runBfs()} disabled={selectedItem?.type !== 'node'}>
+						Highlight connected nodes
+					</Button>
+					<Button onClick={convertToPizza} disabled={selectedItem?.type !== 'node'}>
+						Convert to Pizza
+					</Button>
 				</div>
 			</MenuSection>
 			<Divider variant="small" style={{ width: '100%' }} />

--- a/src/core/baseGraphOperations.ts
+++ b/src/core/baseGraphOperations.ts
@@ -251,7 +251,11 @@ function createEdgePropPatches(
 	);
 }
 
-export function deletePropFromNode(node: GraphNode, prop: Prop, value: unknown): BindFunction {
+export function deletePropFromNode(
+	node: GraphNode,
+	prop: Prop,
+	value: PatchProp['value']
+): BindFunction {
 	return (state: PatchGraphResult) => {
 		const store = state.graphState.nodeStore;
 
@@ -279,7 +283,7 @@ export function deletePropFromNode(node: GraphNode, prop: Prop, value: unknown):
 						id: node.id,
 						type: 'property',
 						elementType: 'node',
-						prop: { key: prop.key, type: 'direct', value: value } as PatchDirectProp,
+						prop: toPatchProp(prop, value),
 					} as GraphPropertyPatch,
 				},
 			],
@@ -383,7 +387,7 @@ export function addEdgeProp(
 	};
 }
 
-function toPatchProp(prop: Prop, value: GraphPropertyPatch['prop']['value']): PatchProp {
+function toPatchProp(prop: Prop, value: PatchProp['value']): PatchProp {
 	switch (prop.type) {
 		case 'direct':
 			const directProp: PatchDirectProp = {


### PR DESCRIPTION
Fixes an issue where the prop field in the GraphPropertyPatch was fixed to type `PatchDirectProp` in the `deletePropFromNode()` function. See [8863600](https://github.com/equinor/rdf-graph/pull/330/commits/88636007d6d99209d60070045779ad9dd98f5445).

Also adds a cool "Convert to Pizza" button in the UI. This tests **hasTemplate** predicate and **custom properties.**