### PR TITLE
fix: bug when removing predicate data

### DIFF
--- a/src/core/complexGraphOperations.ts
+++ b/src/core/complexGraphOperations.ts
@@ -225,11 +225,12 @@ export function cleanEmptyNodes(rdfPatch: RdfPatch): BindFunction {
 
 		const subjectNode = state.graphState.nodeStore[subjectIri];
 		const objectNode = state.graphState.nodeStore[objectTerm];
+
 		let bindings = [];
 		const edges = Object.keys(state.graphState.edgeStore).map(
 			(key) => state.graphState.edgeStore[key]
 		);
-		if (isEmpty(subjectNode, edges)) {
+		if (subjectNode && isEmpty(subjectNode, edges)) {
 			bindings.push(deleteNode(subjectIri));
 		}
 		if (objectNode && isEmpty(objectNode, edges)) {

--- a/src/core/tests/predicate-node.test.ts
+++ b/src/core/tests/predicate-node.test.ts
@@ -1,7 +1,6 @@
 import { DataFactory } from 'n3';
-import { newGraphState, toAddPatch } from './test-utils';
+import { createChangePatches, toAddPatch, toRemovePatch } from './test-utils';
 import { GraphEdge, GraphPropertyPatch } from '../types/core';
-import { patchGraphState } from '../patch';
 import { directPropConfig } from '../propConfig';
 
 const { quad: q, literal: l, namedNode: n } = DataFactory;
@@ -9,24 +8,20 @@ const { quad: q, literal: l, namedNode: n } = DataFactory;
 describe('Predicate nodes', () => {
 	it('Property before edge', () => {
 		//Arrange
-		const state = newGraphState();
-		const oldPatches = toAddPatch([
+		const existingData = [
 			q(n('Edge'), n(directPropConfig.stroke.iri), l('green')),
 			q(n('Edge'), n('SomeDataProp'), l('someValue')),
 			q(n('Edge'), n('SomeEdgyEdge'), n('SomeNode')),
-		]);
-		const oldResult = patchGraphState(state, oldPatches);
+		];
 		const change = toAddPatch([q(n('A'), n('Edge'), n('B'))]);
 
 		// Act
-		const newResult = patchGraphState(oldResult.graphState, change);
+		const patches = createChangePatches(existingData, change);
 
 		// Assert
 
-		const addEdgePatch = newResult.graphPatches.find(
-			(p) => p.action === 'add' && p.content.type === 'edge'
-		);
-		const addEdgePropPatch = newResult.graphPatches.find(
+		const addEdgePatch = patches.find((p) => p.action === 'add' && p.content.type === 'edge');
+		const addEdgePropPatch = patches.find(
 			(p) => p.action === 'add' && p.content.type === 'property'
 		);
 		expect(addEdgePatch).toBeTruthy();
@@ -41,17 +36,36 @@ describe('Predicate nodes', () => {
 
 	it('Edge before property', () => {
 		//Arrange
-		const state = newGraphState();
-		const oldPatches = toAddPatch([q(n('A'), n('Edge'), n('B'))]);
+		const existingData = [q(n('A'), n('Edge'), n('B'))];
 		const change = toAddPatch([q(n('Edge'), n(directPropConfig.stroke.iri), l('green'))]);
-		const oldResult = patchGraphState(state, oldPatches);
 
 		// Act
-		const newResult = patchGraphState(oldResult.graphState, change);
+		const patches = createChangePatches(existingData, change);
 
 		// Assert
-		const addEdgePropPatch = newResult.graphPatches.find(
+		const addEdgePropPatch = patches.find(
 			(p) => p.action === 'add' && p.content.type === 'property'
+		);
+		expect(addEdgePropPatch).toBeTruthy();
+		const edgeProperty = addEdgePropPatch?.content as GraphPropertyPatch;
+		expect(edgeProperty.prop.key).toBe('stroke');
+		expect(edgeProperty.prop.value).toBe('green');
+	});
+
+	it('Remove property', () => {
+		//Arrange
+		const existingData = [
+			q(n('A'), n('Edge'), n('B')),
+			q(n('Edge'), n(directPropConfig.stroke.iri), l('green')),
+		];
+		const change = toRemovePatch([q(n('Edge'), n(directPropConfig.stroke.iri), l('green'))]);
+
+		// Act
+		const patches = createChangePatches(existingData, change);
+
+		// Assert
+		const addEdgePropPatch = patches.find(
+			(p) => p.action === 'remove' && p.content.type === 'property'
 		);
 		expect(addEdgePropPatch).toBeTruthy();
 		const edgeProperty = addEdgePropPatch?.content as GraphPropertyPatch;


### PR DESCRIPTION
If a node is completly detached from the rest of the graph, i.e. no properties or edges to or from the node, it should be removed. The detection of this state was buggy as we assumed the subject would exist as node in the graph state since something has just been removed from the subject. Either a property or a related edge. Forgot to think of the case where the property was removed from as predicate node. In this case the subject (referencing the predicate node) would most likely (always?) be non existing in node store.

Added test and fixed bug