### PR TITLE
feat: support gojs edge templates

### DIFF
--- a/apps/playground/src/components/go/init.ts
+++ b/apps/playground/src/components/go/init.ts
@@ -6,6 +6,7 @@ import { createDefaultLinkTemplate } from './templates/default-link-template';
 import { createDefaultNodeTemplate } from './templates/default-node-template';
 import { createPizzaNodeTemplate } from './templates/pizza-node-template';
 import { createSymbolNodeTemplate } from './templates/symbol-node-template';
+import { createTestLinkTemplate } from './templates/test-link-template';
 
 const clickHandler = (_e: go.InputEvent, _thisObj: go.GraphObject) => {
 	// console.log('Node clicked!');
@@ -34,7 +35,9 @@ export function defaultInitDiagram() {
 			.add(nodeCategory.default, createDefaultNodeTemplate(clickHandler))
 			.add(nodeCategory.symbolWithConnectors, createSymbolNodeTemplate(symbolNodeClickHandler))
 			.add('pizza', createPizzaNodeTemplate()),
-		linkTemplateMap: new go.Map<string, go.Link>().add('', createDefaultLinkTemplate()),
+		linkTemplateMap: new go.Map<string, go.Link>()
+			.add('', createDefaultLinkTemplate())
+			.add('testlink', createTestLinkTemplate()),
 		groupTemplate: createDefaultGroupTemplate(),
 	});
 

--- a/apps/playground/src/components/go/templates/test-link-template.ts
+++ b/apps/playground/src/components/go/templates/test-link-template.ts
@@ -1,0 +1,10 @@
+import * as go from 'gojs';
+
+export function createTestLinkTemplate(): go.Link {
+	return (
+		new go.Link()
+			.add(
+				new go.Shape({ stroke: 'cyan', strokeWidth: 20 })
+			)
+	);
+}

--- a/apps/playground/src/components/go/templates/test-link-template.ts
+++ b/apps/playground/src/components/go/templates/test-link-template.ts
@@ -1,10 +1,5 @@
 import * as go from 'gojs';
 
 export function createTestLinkTemplate(): go.Link {
-	return (
-		new go.Link()
-			.add(
-				new go.Shape({ stroke: 'cyan', strokeWidth: 20 })
-			)
-	);
+	return new go.Link().add(new go.Shape({ stroke: 'cyan', strokeWidth: 20 }));
 }

--- a/libs/go/src/applyPatch.ts
+++ b/libs/go/src/applyPatch.ts
@@ -299,13 +299,15 @@ function removeEdge(diagram: go.Diagram, edge: GraphEdge): void {
 function addEdgeProp(diagram: go.Diagram, propPatch: GraphPropertyPatch) {
 	const linkData = (diagram.model as go.GraphLinksModel).findLinkDataForKey(propPatch.id);
 	if (!linkData) {
-		console.warn("Trying to set property on edge, but unable to find link for id " + propPatch.id)
+		console.warn('Trying to set property on edge, but unable to find link for id ' + propPatch.id);
 		return;
 	}
 	if (propPatch.prop.key === 'template') {
 		const linkForKey = diagram.findLinkForKey(propPatch.id);
 		if (!linkForKey) {
-			console.warn("Trying to set template on edge, but unable to find link for id " + propPatch.id)
+			console.warn(
+				'Trying to set template on edge, but unable to find link for id ' + propPatch.id
+			);
 			return;
 		}
 		(diagram.model as go.GraphLinksModel).setCategoryForNodeData(linkForKey, propPatch.prop.value);

--- a/libs/go/src/applyPatch.ts
+++ b/libs/go/src/applyPatch.ts
@@ -298,7 +298,20 @@ function removeEdge(diagram: go.Diagram, edge: GraphEdge): void {
 
 function addEdgeProp(diagram: go.Diagram, propPatch: GraphPropertyPatch) {
 	const linkData = (diagram.model as go.GraphLinksModel).findLinkDataForKey(propPatch.id);
-	if (!linkData) return;
+	if (!linkData) {
+		console.warn("Trying to set property on edge, but unable to find link for id " + propPatch.id)
+		return;
+	}
+	if (propPatch.prop.key === 'template') {
+		const linkForKey = diagram.findLinkForKey(propPatch.id);
+		if (!linkForKey) {
+			console.warn("Trying to set template on edge, but unable to find link for id " + propPatch.id)
+			return;
+		}
+		(diagram.model as go.GraphLinksModel).setCategoryForNodeData(linkForKey, propPatch.prop.value);
+		return;
+	}
+
 	diagram.model.setDataProperty(linkData, getPropKey(propPatch.prop), propPatch.prop.value);
 }
 


### PR DESCRIPTION
Was a bit hard to figure out how to change edge categories in gojs.

This thread https://forum.nwoods.com/t/dynamically-change-link-category-with-multiple-link-templates/11464/7
and this jsfiddle https://codepen.io/jhardy/pen/xmgJgw?editors=1010 helped

Main idea is that we can use linkdata accessable from `(diagram.model as go.GraphLinksModel).findLinkDataForKey(propPatch.id)` for updating props on link, but when we want to change category we need an acutal link object accessable from either select `myDiagram.selection.first();` or `diagram.findLinkForKey(propPatch.id)`

[AB#110833](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/110833)