### PR TITLE
fix(go): port mapping bugfix in gojs impl

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -53,4 +53,3 @@ jobs:
 
       - name: Test dependencies for known issues
         run: pnpm nx affected --targets=snyk-test --configuration=production --output-style=stream --base=${{ env.NX_BASE }} --head=${{ env.NX_HEAD }} --parallel=5
-

--- a/.github/workflows/cron-snyk.yaml
+++ b/.github/workflows/cron-snyk.yaml
@@ -26,7 +26,7 @@ jobs:
         run: snyk auth ${{ secrets.SNYK_TOKEN }}
 
       - name: Update snapshots at Snyk.io
-        continue-on-error: true 
+        continue-on-error: true
         run: pnpm nx run-many --target=snyk-monitor --output-style=stream
 
       - name: Snyk test

--- a/docs/data/symbol-demo.ttl
+++ b/docs/data/symbol-demo.ttl
@@ -1,0 +1,35 @@
+@prefix ex: <http://example.com/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ui:      <http://rdf.equinor.com/ui/> .
+
+# Add some kind of vessel
+ex:vessel_a rdfs:label "Vessel A" .
+
+# Add pump
+ex:pump rdfs:label "Liquid Pump 1";
+	ui:hasEngineeringSymbol "PP007A" ;
+	ui:fill "#B9E9FC" ;
+	ui:hasConnector ex:pump_c1 , ex:pump_c2 .
+
+ex:pump_c1 ui:hasConnectorName "1" .
+ex:pump_c2 ui:hasConnectorName "2" .
+
+# Add separator
+ex:separator rdfs:label "Separator";
+    ui:fill "#E49393";
+    ui:hasEngineeringSymbol "PT002AOption1";
+    ui:hasConnector ex:separator_C1, 
+					ex:separator_C2, 
+					ex:separator_C3, 
+					ex:separator_C4 .
+
+ex:separator_C1 ui:hasConnectorName "1".
+ex:separator_C2 ui:hasConnectorName "2".
+ex:separator_C3 ui:hasConnectorName "3".
+ex:separator_C4 ui:hasConnectorName "4".
+
+# Connect vessel and pump
+ex:vessel_a ui:connectedTo ex:pump_c2 .
+
+# Connect pump and separator
+ex:pump_c1 ui:connectedTo ex:separator_C3 .

--- a/libs/go/src/applyPatch.ts
+++ b/libs/go/src/applyPatch.ts
@@ -174,7 +174,7 @@ function addNodeProp(diagram: go.Diagram, state: RdfGoGraphState, propPatch: Gra
 }
 
 function addConnectorNodeProp(
-	diagram: go.Diagram,
+	_diagram: go.Diagram,
 	state: RdfGoGraphState,
 	propPatch: GraphPropertyPatch
 ) {
@@ -187,40 +187,6 @@ function addConnectorNodeProp(
 	} else {
 		state.connectorNodes[propPatch.id] = { portId: portId };
 	}
-
-	// Update any links that use this connector
-
-	// BUG: We cannot do this because there might be multiple links to/from the same node to/from different ports,
-	// and the code below will overwrite existing portIds for links to/from the node.
-	// This means that we relay on that the connector name is available when the edge is added in
-	//     'addEdge' func in:
-	// 				const sourceConnector = state.connectorNodes[edge.sourceId];
-	//  			const targetConnector = state.connectorNodes[edge.targetId];
-	//
-
-	// Disable rest of this function for now
-
-	// const symbolNodeId = state.connectorNodes[propPatch.id].symbolNodeId;
-
-	// if (!symbolNodeId) return;
-
-	// const linkMod = diagram.model as go.GraphLinksModel;
-
-	// diagram.links.each((link) => {
-	// 	const d = link.data;
-
-	// 	if (d.to === symbolNodeId) {
-	// 		const exLink = linkMod.findLinkDataForKey(d.id);
-	// 		if (exLink && !exLink.toPort) linkMod.setToPortIdForLinkData(exLink, portId);
-	// 		//if (exLink) linkMod.setToPortIdForLinkData(exLink, portId);
-	// 	}
-
-	// 	if (d.from === symbolNodeId) {
-	// 		const exLink = linkMod.findLinkDataForKey(d.id);
-	// 		if (exLink && !exLink.fromPort) linkMod.setFromPortIdForLinkData(exLink, portId);
-	// 		//if (exLink) linkMod.setFromPortIdForLinkData(exLink, portId);
-	// 	}
-	// });
 }
 
 function removeNodeProp(diagram: go.Diagram, propPatch: GraphPropertyPatch) {

--- a/libs/go/src/applyPatch.ts
+++ b/libs/go/src/applyPatch.ts
@@ -180,6 +180,7 @@ function addConnectorNodeProp(
 ) {
 	if (propPatch.prop.type !== 'custom' && propPatch.prop.key !== 'connectorName') return;
 
+	// Just store the portId for now. We will use it when adding the edge.
 	const portId = propPatch.prop.value;
 
 	if (propPatch.id in state.connectorNodes) {

--- a/libs/go/src/applyPatch.ts
+++ b/libs/go/src/applyPatch.ts
@@ -189,25 +189,38 @@ function addConnectorNodeProp(
 	}
 
 	// Update any links that use this connector
-	const symbolNodeId = state.connectorNodes[propPatch.id].symbolNodeId;
 
-	if (!symbolNodeId) return;
+	// BUG: We cannot do this because there might be multiple links to/from the same node to/from different ports,
+	// and the code below will overwrite existing portIds for links to/from the node.
+	// This means that we relay on that the connector name is available when the edge is added in
+	//     'addEdge' func in:
+	// 				const sourceConnector = state.connectorNodes[edge.sourceId];
+	//  			const targetConnector = state.connectorNodes[edge.targetId];
+	//
 
-	const linkMod = diagram.model as go.GraphLinksModel;
+	// Disable rest of this function for now
 
-	diagram.links.each((link) => {
-		const d = link.data;
+	// const symbolNodeId = state.connectorNodes[propPatch.id].symbolNodeId;
 
-		if (d.to === symbolNodeId) {
-			const exLink = linkMod.findLinkDataForKey(d.id);
-			if (exLink) linkMod.setToPortIdForLinkData(exLink, portId);
-		}
+	// if (!symbolNodeId) return;
 
-		if (d.from === symbolNodeId) {
-			const exLink = linkMod.findLinkDataForKey(d.id);
-			if (exLink) linkMod.setFromPortIdForLinkData(exLink, portId);
-		}
-	});
+	// const linkMod = diagram.model as go.GraphLinksModel;
+
+	// diagram.links.each((link) => {
+	// 	const d = link.data;
+
+	// 	if (d.to === symbolNodeId) {
+	// 		const exLink = linkMod.findLinkDataForKey(d.id);
+	// 		if (exLink && !exLink.toPort) linkMod.setToPortIdForLinkData(exLink, portId);
+	// 		//if (exLink) linkMod.setToPortIdForLinkData(exLink, portId);
+	// 	}
+
+	// 	if (d.from === symbolNodeId) {
+	// 		const exLink = linkMod.findLinkDataForKey(d.id);
+	// 		if (exLink && !exLink.fromPort) linkMod.setFromPortIdForLinkData(exLink, portId);
+	// 		//if (exLink) linkMod.setFromPortIdForLinkData(exLink, portId);
+	// 	}
+	// });
 }
 
 function removeNodeProp(diagram: go.Diagram, propPatch: GraphPropertyPatch) {
@@ -283,10 +296,10 @@ function addEdge(diagram: go.Diagram, state: RdfGoGraphState, edge: GraphEdge) {
 	(diagram.model as go.GraphLinksModel).addLinkData({
 		id: edge.id,
 		type: edge.type,
-		from: from,
-		fromPort: fromPort,
-		to: to,
-		toPort: toPort,
+		from,
+		fromPort,
+		to,
+		toPort,
 	});
 }
 


### PR DESCRIPTION
Attempt to fix bug in gojs where edges was connecting to the same port even though they was mapped to different ports. Seems to work.

Now, we ignore changing** existing links/edges that go to or from a node X when a "connectorName" prop on a connector node comes after an edge to/from X has been added. 

** Before, we used to set 'toPort' and/or 'fromPort' on links to/from X.



We cannot do this because there might be multiple links to/from the same node to/from different ports, and the deleted code in 'addConnectorNodeProp(...)' func will overwrite existing portIds for links to/from the node. This means that we relay on that the connectorNames that is available when the edge is added
```
function addEdge(diagram: go.Diagram, state: RdfGoGraphState, edge: GraphEdge) {
	// Check if 'from' and/or 'to' is a symbol connector
	const sourceConnector = state.connectorNodes[edge.sourceId];
	const targetConnector = state.connectorNodes[edge.targetId];
```
`sourceConnector` and `targetConnector` should have the portIds already.

